### PR TITLE
Fix CLI router test timeouts in CI

### DIFF
--- a/src/cli/cli-router.ts
+++ b/src/cli/cli-router.ts
@@ -27,6 +27,7 @@ export class CliRouter {
         if (fileIdx !== -1 && (!fileArg || fileArg.startsWith('--'))) {
           console.error('[ctxo] --file requires a path argument');
           process.exit(1);
+          return;
         }
         const checkArg = args.includes('--check');
         const skipHistory = args.includes('--skip-history');
@@ -35,6 +36,7 @@ export class CliRouter {
         if (maxHistoryIdx !== -1 && (!maxHistoryArg || isNaN(maxHistoryArg) || maxHistoryArg < 1)) {
           console.error('[ctxo] --max-history requires a positive integer');
           process.exit(1);
+          return;
         }
         await new IndexCommand(this.projectRoot).run({ file: fileArg, check: checkArg, skipHistory, maxHistory: maxHistoryArg });
         break;
@@ -63,6 +65,7 @@ export class CliRouter {
       default:
         console.error(`[ctxo] Unknown command: "${command}". Run "ctxo --help" for usage.`);
         process.exit(1);
+        return;
     }
   }
 


### PR DESCRIPTION
## Summary
- CLI router tests (`--max-history` validation) were timing out in CI (5s limit)
- Root cause: when `process.exit` is mocked, execution continues into `IndexCommand.run()` which runs the full indexer
- Fix: add `return` after each `process.exit(1)` call so control flow stops even when the mock swallows the exit
- Tests now complete in **4ms** instead of ~10s

## Test plan
- [x] `npx vitest run src/cli/__tests__/cli-router.test.ts` — 9/9 pass in 4ms
- [x] All Node 20 + Node 22 CI matrix should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)