### PR TITLE
fix(graph): resolve TS2532 errors in SymbolGraph fuzzy resolution

### DIFF
--- a/src/core/graph/symbol-graph.ts
+++ b/src/core/graph/symbol-graph.ts
@@ -10,9 +10,9 @@ export class SymbolGraph {
   addNode(node: SymbolNode): void {
     this.nodes.set(node.symbolId, node);
     // Index by file::name (ignoring kind) for fuzzy edge resolution
-    const parts = node.symbolId.split('::');
-    if (parts.length >= 2) {
-      this.nodesByFileAndName.set(`${parts[0]}::${parts[1]}`, node);
+    const [p0, p1] = node.symbolId.split('::');
+    if (p0 !== undefined && p1 !== undefined) {
+      this.nodesByFileAndName.set(`${p0}::${p1}`, node);
     }
   }
 
@@ -41,16 +41,16 @@ export class SymbolGraph {
 
   private resolveNodeId(id: string): string {
     if (this.nodes.has(id)) return id;
-    const parts = id.split('::');
-    if (parts.length >= 2) {
-      const fuzzyKey = `${parts[0]}::${parts[1]}`;
+    const [p0, p1] = id.split('::');
+    if (p0 !== undefined && p1 !== undefined) {
+      const fuzzyKey = `${p0}::${p1}`;
       const match = this.nodesByFileAndName.get(fuzzyKey);
       if (match) return match.symbolId;
 
       // Try .js → .ts extension swap (handles unresolved module specifiers)
-      const jsToTs = parts[0].replace(/\.js$/, '.ts');
-      if (jsToTs !== parts[0]) {
-        const altKey = `${jsToTs}::${parts[1]}`;
+      const jsToTs = p0.replace(/\.js$/, '.ts');
+      if (jsToTs !== p0) {
+        const altKey = `${jsToTs}::${p1}`;
         const altMatch = this.nodesByFileAndName.get(altKey);
         if (altMatch) return altMatch.symbolId;
       }
@@ -59,15 +59,15 @@ export class SymbolGraph {
   }
 
   private resolveNodeFuzzy(id: string): SymbolNode | undefined {
-    const parts = id.split('::');
-    if (parts.length >= 2) {
-      const match = this.nodesByFileAndName.get(`${parts[0]}::${parts[1]}`);
+    const [p0, p1] = id.split('::');
+    if (p0 !== undefined && p1 !== undefined) {
+      const match = this.nodesByFileAndName.get(`${p0}::${p1}`);
       if (match) return match;
 
       // Try .js → .ts extension swap (consistent with resolveNodeId)
-      const jsToTs = parts[0].replace(/\.js$/, '.ts');
-      if (jsToTs !== parts[0]) {
-        return this.nodesByFileAndName.get(`${jsToTs}::${parts[1]}`);
+      const jsToTs = p0.replace(/\.js$/, '.ts');
+      if (jsToTs !== p0) {
+        return this.nodesByFileAndName.get(`${jsToTs}::${p1}`);
       }
     }
     return undefined;


### PR DESCRIPTION
## What

`tsconfig.json` has `noUncheckedIndexedAccess: true`, which types array element access as `T | undefined` regardless of length guards.

`resolveNodeId()` and `resolveNodeFuzzy()` called `.replace()` on `parts[0]` inside `if (parts.length >= 2)` — TypeScript can't narrow element types from a length check, so it reported TS2532 on both methods.

## Fix

Replaced index access with destructuring. TypeScript narrows destructured elements correctly when checked against `undefined`:

```ts
// before
const parts = id.split('::');
if (parts.length >= 2) {
  const jsToTs = parts[0].replace(...); // TS2532

// after
const [p0, p1] = id.split('::');
if (p0 !== undefined && p1 !== undefined) {
  const jsToTs = p0.replace(...); // clean
```

Applied to `addNode`, `resolveNodeId`, and `resolveNodeFuzzy`. No semantic change — 14 symbol-graph tests pass.

## Impact

Unblocks typecheck CI on the two open dependabot PRs (#17, #18).