### PR TITLE
fix(storage): make JSON index writes atomic via tmp+rename

### DIFF
--- a/src/adapters/storage/__tests__/json-index-writer.test.ts
+++ b/src/adapters/storage/__tests__/json-index-writer.test.ts
@@ -99,4 +99,13 @@ describe('JsonIndexWriter', () => {
   it('does not throw when deleting non-existent file', () => {
     expect(() => writer.delete('src/nonexistent.ts')).not.toThrow();
   });
+
+  it('does not leave .tmp files after write', () => {
+    writer.write(buildFileIndex());
+
+    const indexDir = join(tempDir, 'index', 'src');
+    const files = require('node:fs').readdirSync(indexDir) as string[];
+    const tmpFiles = files.filter((f: string) => f.endsWith('.tmp'));
+    expect(tmpFiles).toHaveLength(0);
+  });
 });

--- a/src/adapters/storage/json-index-writer.ts
+++ b/src/adapters/storage/json-index-writer.ts
@@ -29,7 +29,7 @@ export class JsonIndexWriter {
   }
 
   private atomicWrite(targetPath: string, content: string): void {
-    const tmpPath = `${targetPath}.tmp`;
+    const tmpPath = `${targetPath}.${process.pid}.tmp`;
     writeFileSync(tmpPath, content, 'utf-8');
     renameSync(tmpPath, targetPath);
   }

--- a/src/adapters/storage/json-index-writer.ts
+++ b/src/adapters/storage/json-index-writer.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync, unlinkSync, existsSync } from 'node:fs';
+import { writeFileSync, renameSync, mkdirSync, unlinkSync, existsSync } from 'node:fs';
 import { dirname, join, resolve, sep } from 'node:path';
 import type { FileIndex, CoChangeMatrix } from '../../core/types.js';
 
@@ -19,13 +19,19 @@ export class JsonIndexWriter {
 
     const sorted = this.sortKeys(fileIndex);
     const json = JSON.stringify(sorted, null, 2);
-    writeFileSync(targetPath, json, 'utf-8');
+    this.atomicWrite(targetPath, json);
   }
 
   writeCoChanges(matrix: CoChangeMatrix): void {
     mkdirSync(this.indexDir, { recursive: true });
     const targetPath = join(this.indexDir, 'co-changes.json');
-    writeFileSync(targetPath, JSON.stringify(matrix, null, 2), 'utf-8');
+    this.atomicWrite(targetPath, JSON.stringify(matrix, null, 2));
+  }
+
+  private atomicWrite(targetPath: string, content: string): void {
+    const tmpPath = `${targetPath}.tmp`;
+    writeFileSync(tmpPath, content, 'utf-8');
+    renameSync(tmpPath, targetPath);
   }
 
   delete(relativePath: string): void {


### PR DESCRIPTION
## What

`writeFileSync` writes directly to the target path. If the process is killed mid-write (OOM, SIGKILL, disk full), the JSON file is left partially written.

`JsonIndexReader.readSingle()` catches the `JSON.parse()` error and silently returns `undefined` — the file drops out of the graph without any staleness warning, since the corrupt file still exists with a valid mtime.

## Fix

Write to a `.tmp` sibling first, then `renameSync` to the final path. `rename` is atomic on POSIX and Windows (since Vista). Extracted into a shared `atomicWrite()` helper used by both `write()` and `writeCoChanges()`.

```ts
private atomicWrite(targetPath: string, content: string): void {
  const tmpPath = `${targetPath}.tmp`;
  writeFileSync(tmpPath, content, 'utf-8');
  renameSync(tmpPath, targetPath);
}
```

## Tests

All 12 existing json-index-writer tests pass (writer + edge-cases).