### PR TITLE
fix(mcp): report indexed file count in get_pr_impact, not raw git paths

### DIFF
--- a/src/adapters/mcp/__tests__/get-pr-impact.test.ts
+++ b/src/adapters/mcp/__tests__/get-pr-impact.test.ts
@@ -163,6 +163,18 @@ describe('handleGetPrImpact', () => {
     }
   });
 
+  it('changedFiles counts only indexed source files, not raw git paths', async () => {
+    const git = createMockGit(['src/a.ts', 'tests/a.test.ts', '.eslintrc.js', 'README.md']);
+    const handler = handleGetPrImpact(storage, git, new MaskingPipeline(), undefined, tempDir);
+    const result = await handler({ since: 'HEAD~1' });
+    const payload = JSON.parse(result.content[0]!.text);
+
+    // Only src/a.ts is in the index — others should not inflate changedFiles
+    expect(payload.changedFiles).toBe(1);
+    expect(payload.files).toHaveLength(1);
+    expect(payload.files[0].file).toBe('src/a.ts');
+  });
+
   it('returns error for invalid input', async () => {
     const git = createMockGit([]);
     const handler = handleGetPrImpact(storage, git, new MaskingPipeline(), undefined, tempDir);

--- a/src/adapters/mcp/__tests__/get-pr-impact.test.ts
+++ b/src/adapters/mcp/__tests__/get-pr-impact.test.ts
@@ -175,6 +175,17 @@ describe('handleGetPrImpact', () => {
     expect(payload.files[0].file).toBe('src/a.ts');
   });
 
+  it('respects maxFiles limit', async () => {
+    const git = createMockGit(['src/a.ts', 'src/b.ts', 'src/c.ts']);
+    const handler = handleGetPrImpact(storage, git, new MaskingPipeline(), undefined, tempDir);
+    const result = await handler({ since: 'HEAD~1', maxFiles: 1 });
+    const payload = JSON.parse(result.content[0]!.text);
+
+    // Only the first file should be processed despite 3 changed files
+    expect(payload.files.length).toBeLessThanOrEqual(1);
+    expect(payload.changedFiles).toBeLessThanOrEqual(1);
+  });
+
   it('returns error for invalid input', async () => {
     const git = createMockGit([]);
     const handler = handleGetPrImpact(storage, git, new MaskingPipeline(), undefined, tempDir);

--- a/src/adapters/mcp/get-pr-impact.ts
+++ b/src/adapters/mcp/get-pr-impact.ts
@@ -177,7 +177,7 @@ export function handleGetPrImpact(
 
       const payload = masking.mask(JSON.stringify({
         since,
-        changedFiles: limitedPaths.length,
+        changedFiles: files.length,
         changedSymbols,
         totalImpact,
         riskLevel,


### PR DESCRIPTION
Fixes #23

## What

`changedFiles` used `limitedPaths.length` — the count of all raw git diff paths (tests, configs, fixtures). The `files` array only contains indexed source files with symbols. Result: `{ changedFiles: 50, changedSymbols: 0, files: [] }`.

## Fix

`limitedPaths.length` → `files.length`, consistent with how `get_changed_symbols` already reports this field.

## Test

Added test with non-indexed files (`tests/a.test.ts`, `.eslintrc.js`, `README.md`) in the git mock — verifies `changedFiles` counts only the 1 indexed file.

8/8 tests pass.

---

Also noticed the `todo.md` roadmap — the search quality upgrade (Phase 1) and session continuity (Phase 3) align with analysis I did independently. Happy to pick up one of those after the bug fixes if you want.