### PR TITLE
feat(mcp): register empty prompts/resources handlers for client compat

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,18 @@ async function main(): Promise<void> {
   // Create MCP server
   const server = new McpServer({ name: 'ctxo', version: '0.1.0' });
 
+  // Register empty prompts/resources handlers so MCP clients that call
+  // listPrompts()/listResources() during init don't get -32601 errors.
+  const { ListPromptsRequestSchema, ListResourcesRequestSchema, ListResourceTemplatesRequestSchema } =
+    await import('@modelcontextprotocol/sdk/types.js');
+  server.server.registerCapabilities({
+    prompts: { listChanged: false },
+    resources: { listChanged: false },
+  });
+  server.server.setRequestHandler(ListPromptsRequestSchema, async () => ({ prompts: [] }));
+  server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));
+  server.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({ resourceTemplates: [] }));
+
   // Staleness detection
   const { StalenessDetector } = await import('./core/staleness/staleness-detector.js');
   const staleness = new StalenessDetector(process.cwd(), ctxoRoot);


### PR DESCRIPTION
Fixes #29

## What

MCP clients that call `listPrompts()` / `listResources()` during init get `-32601 Method not found` because Ctxo only registers tools. Not fatal, but noisy logs and potential transport poisoning in some SDK implementations (OpenCode hit this with context-mode).

## Fix

Register empty capability handlers via `server.server` (low-level API) that return empty arrays. Same pattern context-mode uses.

```typescript
server.server.registerCapabilities({
  prompts: { listChanged: false },
  resources: { listChanged: false },
});
server.server.setRequestHandler(ListPromptsRequestSchema, async () => ({ prompts: [] }));
server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));
server.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({ resourceTemplates: [] }));
```

`listChanged: false` — no notifications, just empty lists.

## Tests

11/11 MCP spec compliance e2e tests pass.