### PR TITLE
fix(cli): route --http flag to HTTP transport instead of CLI router

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,11 @@ function loadMaskingConfig(ctxoRoot: string): MaskingPipeline {
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
-  if (args.length > 0) {
+  // HTTP mode — check before CLI routing since --http is a server flag, not a CLI command
+  const httpPortStr = process.env.CTXO_HTTP_PORT
+    || (args.includes('--http') ? (args[args.indexOf('--port') + 1] || '3001') : null);
+
+  if (!httpPortStr && args.length > 0) {
     // CLI mode
     const { CliRouter } = await import('./cli/cli-router.js');
     const router = new CliRouter(process.cwd());
@@ -72,9 +76,6 @@ async function main(): Promise<void> {
   registerTools(server, storage, masking, git, staleness, ctxoRoot);
 
   // Start MCP server — HTTP mode or stdio mode
-  const httpPortStr = process.env.CTXO_HTTP_PORT
-    || (process.argv.includes('--http') ? (process.argv[process.argv.indexOf('--port') + 1] || '3001') : null);
-
   if (httpPortStr) {
     await startHttpTransport(async () => {
       const s = new McpServer({ name: 'ctxo', version: '0.1.0' });


### PR DESCRIPTION
## What

`--http` flag is intercepted by the CLI router before reaching the HTTP transport branch.

```
node dist/index.js --http
→ CliRouter.route(["--http"])
→ "Unknown command: --http"
→ exit
```

The `if (args.length > 0)` check at line 49 catches all arguments including server flags.

## Fix

Move HTTP flag detection (`--http`, `--port`, `CTXO_HTTP_PORT`) before CLI routing:

```typescript
const httpPortStr = process.env.CTXO_HTTP_PORT
  || (args.includes('--http') ? ... : null);

if (!httpPortStr && args.length > 0) {
  // CLI mode — only non-HTTP args reach the router
}
```

Also removes the duplicate `httpPortStr` computation that was unreachable after the early return.

## Verification

- `node dist/index.js --http` → HTTP server starts on port 3001
- `CTXO_HTTP_PORT=3001 node dist/index.js` → same via env var
- `node dist/index.js index` → CLI routing unchanged
- `node dist/index.js` (no args) → stdio MCP server unchanged