### PR TITLE
fix(tests): resolve pre-existing test suite failures (1044/1044 green)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Golden snapshots must stay LF so byte-identical comparisons hold on Windows.
+packages/cli/src/core/overlay/__tests__/fixtures/golden-community-snapshot.json text eol=lf

--- a/docs/runbook/mcp-validation/mcp-validation-test.ts
+++ b/docs/runbook/mcp-validation/mcp-validation-test.ts
@@ -25,7 +25,7 @@ import { join } from 'node:path';
 
 async function main() {
   const ctxoRoot = '.ctxo';
-  const storage = new SqliteStorageAdapter(ctxoRoot);
+  const storage = new SqliteStorageAdapter(ctxoRoot, { allowProductionPath: true });
   await storage.init();
   const masking = new MaskingPipeline();
   const git = new SimpleGitAdapter(process.cwd());

--- a/docs/runbook/mcp-validation/test-sessions/v2.4.md
+++ b/docs/runbook/mcp-validation/test-sessions/v2.4.md
@@ -1,0 +1,124 @@
+# Ctxo MCP Server -- Test Session v2.4
+
+> **Date:** 2026-04-16
+> **Tester:** Claude Opus 4.6 (automated)
+> **Ctxo Version:** feat/architectural-intelligence @ `190f929`
+> **Node.js:** v24.3.0
+> **Duration:** ~20s (index 3.7s + smoke 14/14 + unit 7.3s)
+
+***
+
+## Executive Summary
+
+Second full-runbook pass. Index built in 3.74s across 290 source files (262 TS/JS + 22 Go + 6 C#, modularity 0.714, 414 clusters, 1126 co-change pairs). **Smoke-test runner now passes 14/14** after two fixes to [`mcp-validation-test.ts`](../mcp-validation-test.ts): import paths updated to monorepo layout (`../../../packages/cli/src/...`) and `SqliteStorageAdapter` constructor now passes `{ allowProductionPath: true }` to satisfy the new `CommunitySnapshotWriter` guard added in `190f929`. Unit tests: 1024/1025 pass; one pre-existing async syntax error in `get-blast-radius.test.ts` and one Windows CRLF golden-snapshot mismatch in `community-detector.golden.test.ts` — neither introduced by this session's work.
+
+***
+
+## Step 1-2: Clean Slate + Rebuild
+
+| Metric        | Value                                              |
+| ------------- | -------------------------------------------------- |
+| Files indexed | 290                                                |
+| Build time    | 3.74s                                              |
+| Languages     | TS/JS: 262, Go: 22, C#: 6                          |
+| Clusters      | 414                                                |
+| Modularity    | 0.714                                              |
+| Co-change     | 1126 file pairs                                    |
+
+* [x] `[ctxo] Index complete: 290 files indexed`
+* [x] Modularity 0.714 ≥ 0.3 gate
+* [x] Build < 10s
+* [!] Two stale file references (ENOENT) skipped: `packages/cli/src/core/report/report-payload-builder.ts`, `packages/cli/src/core/report/report-payload.ts` — git ls-files still references deleted paths
+
+## Step 3: Index Metrics
+
+| Metric                 | Value                                                       |
+| ---------------------- | ----------------------------------------------------------- |
+| Files                  | 292 (incl. manifest)                                        |
+| Symbols                | 837                                                         |
+| Edges                  | 2042                                                        |
+| Intents                | 473                                                         |
+| AntiPatterns           | 0                                                           |
+| Symbols w/ byte offset | 837 (100%)                                                  |
+| typeOnly edges         | 306                                                         |
+| Edge kinds             | imports=936, calls=650, uses=423, implements=30, extends=3  |
+
+***
+
+## Appendix A: Automated Smoke Test — 14/14 PASS
+
+```
+get_logic_slice:          PASS | root=LogicSliceQuery deps=4 edges=12
+get_blast_radius:         PASS | impact=109 conf=21 pot=56 risk=1.000
+get_architectural_overlay:PASS | Unknown=30 Test=127 Adapter=73 Composition=6 Configuration=9 Domain=46
+get_why_context:          PASS | commits=1 anti=0
+get_change_intelligence:  PASS | cx=0.444 churn=0.500 comp=0.222 band=low
+find_dead_code:           PASS | total=777 reach=469 dead=1 files=14 pct=39.6% unused=127 scaff=0
+get_context_for_task:     PASS | ctx=9 tok=3997
+get_ranked_context:       PASS | res=8 tok=674 top=IMaskingPort
+search_symbols:           PASS | match=14 top=handleFindImporters
+get_changed_symbols:      PASS | files=0 syms=0
+find_importers:           PASS | imp=60 maxD=2
+get_class_hierarchy:      PASS | hier=7 cls=48 edges=33
+get_symbol_importance:    PASS | syms=837 conv=true iter=27 top=SqliteStorageAdapter.database
+get_pr_impact:            PASS | files=0 syms=0 risk=low
+=== RESULT: 14/14 passed, 0 failed ===
+```
+
+### Smoke-test runner fixes applied in this session
+
+1. **Monorepo import paths** — 18 occurrences of `../../../src/...` → `../../../packages/cli/src/...` (stale since pnpm-migration commit `71d95d2`)
+2. **Fixture symbolIds** — 6 occurrences in the test table rewritten from `src/...::...` to `packages/cli/src/...::...`
+3. **CommunitySnapshotWriter guard** — new `{ allowProductionPath: true }` option required on `SqliteStorageAdapter` when pointing at `.ctxo/` (not a tmpdir). Added by `190f929`.
+
+### Invocation caveat
+
+Running the script directly under `pnpm --filter @ctxo/cli exec tsx docs/runbook/mcp-validation/mcp-validation-test.ts` still fails because `@modelcontextprotocol/sdk` resolves relative to the script's location (outside any `node_modules`). Working invocation pattern:
+
+```sh
+cp docs/runbook/mcp-validation/mcp-validation-test.ts packages/cli/tmp-smoke-test.ts
+sed -i "s|'../../../packages/cli/src/|'./src/|g" packages/cli/tmp-smoke-test.ts
+rm -rf .ctxo/.cache/ .ctxo/index/
+pnpm --filter @ctxo/cli exec tsx src/index.ts index
+npx --prefix packages/cli tsx packages/cli/tmp-smoke-test.ts
+rm -f packages/cli/tmp-smoke-test.ts
+```
+
+Ordering matters: tmp file must be placed **before** the index rebuild, or its newer mtime trips `StalenessDetector` and every tool call prepends `⚠️ Index may be stale` (breaking the script's `JSON.parse`). A durable fix would be to colocate the script inside `packages/cli/` permanently (e.g. `packages/cli/scripts/smoke-test.ts`) and add it as a script target.
+
+***
+
+## Step 22: Unit Tests — 1024/1025 PASS
+
+```
+Test Files  89 passed | 2 failed (91)
+Tests       1024 passed | 1 failed (1025)
+Duration    7.33s
+```
+
+### Failures (both pre-existing, not introduced by this session)
+
+1. **`get-blast-radius.test.ts` — transform error**
+   - Test `applies masking to response` at line 90 uses `await` inside a non-`async` arrow. Esbuild refuses the file outright (blocks all 22 tests in it from loading).
+   - Fix: add `async` on the `it(...)` callback.
+2. **`community-detector.golden.test.ts` — CRLF vs LF**
+   - Golden file written with LF; working-copy read returns CRLF on Windows. Test expects byte-identical match.
+   - Fix: either `.gitattributes` `text eol=lf` pin for fixtures, or `readFileSync(...).toString().replace(/\r\n/g,'\n')` in the comparator.
+
+***
+
+## Known Issues Carried Forward (from v2.3)
+
+1. **Masking false-positive on 40-hex strings** — git SHAs + some `sqlite-storage-adapter.ts` paths still rendered `[REDACTED:AWS_SECRET]`.
+2. **Community history empty** — `.ctxo/index/communities.history/` empty after fresh index; drift returns `snapshotsAvailable: 0, confidence: low` (as designed).
+3. **`get_architectural_overlay` full-scan payload exceeds tool cap** — 118 KB when called with no args; filtered mode works fine.
+
+## New Findings This Run
+
+4. **Stale git ls-files entries** — indexer ENOENT-skipped `packages/cli/src/core/report/report-payload.ts` and `report-payload-builder.ts`. Either rm the stale path from git index or teach the ls-files consumer to filter non-existent paths before dispatch.
+
+***
+
+## Result
+
+**14/14 MCP tools PASS via automated smoke test. 1024/1025 unit tests pass (2 pre-existing Windows/syntax issues isolated).**

--- a/packages/cli/src/adapters/mcp/__tests__/get-blast-radius.test.ts
+++ b/packages/cli/src/adapters/mcp/__tests__/get-blast-radius.test.ts
@@ -87,7 +87,7 @@ describe('GetBlastRadiusHandler', () => {
     expect(payload.found).toBe(false);
   });
 
-  it('applies masking to response', () => {
+  it('applies masking to response', async () => {
     // Add a symbol with sensitive name
     const sensitiveIndex: FileIndex = {
       file: 'src/config.ts',
@@ -189,10 +189,10 @@ describe('GetBlastRadiusHandler', () => {
     expect(payload.likelyCount).toBe(0);
   });
 
-  it('returns all entries when no confidence filter', () => {
+  it('returns all entries when no confidence filter', async () => {
     const handler = handleGetBlastRadius(storage, new MaskingPipeline(), undefined, tempDir);
-    const unfiltered = handler({ symbolId: 'src/c.ts::C::interface' });
-    const filtered = handler({ symbolId: 'src/c.ts::C::interface', confidence: 'confirmed' });
+    const unfiltered = await handler({ symbolId: 'src/c.ts::C::interface' });
+    const filtered = await handler({ symbolId: 'src/c.ts::C::interface', confidence: 'confirmed' });
 
     const unfilteredPayload = JSON.parse(unfiltered.content[0]!.text);
     const filteredPayload = JSON.parse(filtered.content[0]!.text);
@@ -207,7 +207,7 @@ describe('GetBlastRadiusHandler', () => {
     expect(payload.byCluster).toBeUndefined();
   });
 
-  it('emits cluster breakdown + multiClusterHint when snapshot covers impacted symbols across clusters', () => {
+  it('emits cluster breakdown + multiClusterHint when snapshot covers impacted symbols across clusters', async () => {
     storage.writeCommunities({
       version: 1,
       computedAt: '2026-04-16T10:00:00.000Z',

--- a/packages/cli/src/core/overlay/__tests__/community-detector.golden.test.ts
+++ b/packages/cli/src/core/overlay/__tests__/community-detector.golden.test.ts
@@ -69,7 +69,7 @@ describe('CommunityDetector — golden snapshot', () => {
       );
     }
 
-    const golden = readFileSync(GOLDEN_PATH, 'utf-8').trimEnd();
+    const golden = readFileSync(GOLDEN_PATH, 'utf-8').replace(/\r\n/g, '\n').trimEnd();
     expect(serialized).toBe(golden);
   });
 


### PR DESCRIPTION
## Summary
- Three unrelated fixes carried over from an earlier session; together they take unit tests from 1029/1030 to **1044/1044** on Windows.
- \`get-blast-radius.test.ts\`: three tests used \`await\` inside non-async arrow functions — added \`async\` + awaited handler calls.
- \`community-detector.golden.test.ts\`: normalize CRLF to LF when reading the golden fixture so byte-identical compare holds on Windows. \`.gitattributes\` pins the fixture to LF for future writes.
- \`mcp-validation-test.ts\`: pass \`{ allowProductionPath: true }\` to \`SqliteStorageAdapter\` so the smoke-test runner works against the production \`.ctxo/\` path guard.
- docs/runbook v2.4 session log added.

## Test plan
- [x] \`pnpm --filter @ctxo/cli test:unit\` — **1044/1044 pass**
- [x] \`pnpm --filter @ctxo/cli typecheck\` — clean