### PR TITLE
fix(core): drop ports/ imports from snapshot-staleness to restore hexagonal boundary

### DIFF
--- a/packages/cli/src/core/overlay/snapshot-staleness.ts
+++ b/packages/cli/src/core/overlay/snapshot-staleness.ts
@@ -1,11 +1,26 @@
-import type { IGitPort } from '../../ports/i-git-port.js';
-import type { IStoragePort } from '../../ports/i-storage-port.js';
+import type { CommunitySnapshot } from '../types.js';
 
 export interface SnapshotStaleness {
   readonly snapshotCommit: string;
   readonly currentHeadCommit?: string;
   readonly commitsBehind?: number;
   readonly hint?: string;
+}
+
+/**
+ * Narrow structural views of the capabilities this module needs from the
+ * storage and git adapters. We declare them here (in core/) rather than
+ * importing the full IStoragePort / IGitPort interfaces from ports/ so the
+ * hexagonal boundary holds: core/ knows nothing about ports/. Callers pass
+ * their existing port-typed adapters — they satisfy these shapes structurally.
+ */
+export interface SnapshotStalenessStorage {
+  readCommunities(): CommunitySnapshot | undefined;
+}
+
+export interface SnapshotStalenessGit {
+  getHeadSha?(): Promise<string | undefined> | string | undefined;
+  countCommitsBetween?(sha: string): Promise<number | undefined> | number | undefined;
 }
 
 /**
@@ -18,8 +33,8 @@ export interface SnapshotStaleness {
  * is unavailable and no comparison is possible.
  */
 export async function buildSnapshotStaleness(
-  storage: IStoragePort,
-  git: IGitPort,
+  storage: SnapshotStalenessStorage,
+  git: SnapshotStalenessGit,
 ): Promise<SnapshotStaleness | undefined> {
   const snapshot = storage.readCommunities();
   if (!snapshot || !snapshot.commitSha || snapshot.commitSha === 'nocommit') return undefined;


### PR DESCRIPTION
## Summary
- CI lint has been failing on master since 0ef4193: \`core/overlay/snapshot-staleness.ts\` imports \`IGitPort\` + \`IStoragePort\` from \`ports/\`, which the ESLint \`no-restricted-imports\` rule forbids (\`core/ must not import from ports/\`).
- Replaces the two port imports with narrow structural interfaces declared in \`core/\` itself (\`SnapshotStalenessStorage\`, \`SnapshotStalenessGit\`).
- Port-typed adapter instances continue to satisfy these shapes structurally — no call-site or test changes required.

## Test plan
- [x] \`pnpm --filter @ctxo/cli lint\` — clean
- [x] \`pnpm --filter @ctxo/cli typecheck\` — clean
- [x] \`pnpm --filter @ctxo/cli test:unit snapshot-staleness\` — 7/7 pass