### PR TITLE
feat(lang-java): add @ctxo/lang-java syntax-tier plugin

### DIFF
--- a/.changeset/add-lang-java.md
+++ b/.changeset/add-lang-java.md
@@ -1,0 +1,14 @@
+---
+"@ctxo/lang-java": minor
+---
+
+Add `@ctxo/lang-java` — Java language plugin (syntax tier).
+
+Built on `tree-sitter-java`. Implements Plugin API v1.
+
+- **Symbols**: classes, interfaces, enums, records, methods, constructors. Nested types are qualified `Outer.Inner`. Methods are qualified `Outer.method`.
+- **Edges**: `imports` (with wildcard skip and static-import normalization), `extends`, `implements`. Edge targets are name-keyed and resolved against the cross-file symbol registry, matching the convention used by `@ctxo/lang-csharp`.
+- **Cyclomatic complexity**: counts `if`, `for`, `enhanced_for`, `while`, `do`, `switch_label`, `catch_clause`, `ternary_expression`, and `&&`/`||` short-circuits.
+- **Detection**: already wired in `@ctxo/cli` (`pom.xml`, `build.gradle`, `build.gradle.kts`, `.java`).
+
+Known limitations (out of scope for this release): sealed `permits` clauses, enum constants with bodies, instance/static initializer blocks, and anonymous inner classes are not surfaced. These require new `SymbolKind`/`EdgeKind` values in `@ctxo/plugin-api`.

--- a/packages/lang-java/README.md
+++ b/packages/lang-java/README.md
@@ -1,0 +1,61 @@
+# @ctxo/lang-java
+
+Ctxo Java language plugin — `syntax` tier, built on `tree-sitter-java`.
+
+## Install
+
+```bash
+pnpm add -D @ctxo/lang-java
+# or
+npm install --save-dev @ctxo/lang-java
+```
+
+The Ctxo CLI auto-detects Java projects (`pom.xml`, `build.gradle`, `build.gradle.kts`, `.java` files) and prompts to install this plugin during `ctxo init`.
+
+## Coverage
+
+### Symbols
+| Java construct          | Ctxo `SymbolKind` | Name format             |
+| ----------------------- | ----------------- | ----------------------- |
+| `class`                 | `class`           | `ClassName`             |
+| `interface`             | `interface`       | `InterfaceName`         |
+| `enum`                  | `class`           | `EnumName`              |
+| `record`                | `class`           | `RecordName`            |
+| Method                  | `method`          | `EnclosingType.method`  |
+| Constructor             | `method`          | `ClassName.ClassName`   |
+| Nested type             | (as above)        | `Outer.Inner`           |
+
+### Edges
+| Java construct                       | `EdgeKind`    |
+| ------------------------------------ | ------------- |
+| `import com.foo.Bar;`                | `imports`     |
+| `import static com.foo.Bar.X;`       | `imports` (normalized to `com.foo.Bar`) |
+| `import com.foo.*;`                  | (skipped — no actionable target) |
+| `class A extends B`                  | `extends`     |
+| `class A implements I`               | `implements`  |
+| `interface A extends B`              | `extends`     |
+
+Edge targets are name-keyed (`TypeName::TypeName::kind`) and resolved against the cross-file symbol registry that the indexer populates in pass 1. When the target type is in the indexed corpus, the resolver binds the edge to the real symbol ID. Otherwise the name-keyed fallback remains, allowing name-based lookups by downstream consumers.
+
+### Cyclomatic complexity
+Branch nodes counted: `if`, `for`, `enhanced_for`, `while`, `do`, `switch_label`, `catch_clause`, `ternary_expression`, plus `&&` / `||` short-circuit operators.
+
+## Known limitations
+
+These constructs are NOT yet surfaced — they require new `SymbolKind`/`EdgeKind` values in `@ctxo/plugin-api`:
+
+- Sealed type `permits` clauses
+- Enum constants with bodies (and abstract enum methods)
+- Instance and static initializer blocks
+- Anonymous inner classes
+- Lambda bodies (the enclosing method is captured; the lambda itself is not surfaced as a symbol)
+
+Files containing only a `package` declaration plus imports (no top-level type, e.g. `package-info.java`) are skipped — there is no top-level symbol to anchor `imports` edges against. This matches the behavior of `@ctxo/lang-go`.
+
+## Tier
+
+Reports `tier: 'syntax'`. A future `full` tier (built on JDT or `javac`) would add resolved call/use edges and richer type information; tracked as a follow-up.
+
+## License
+
+MIT

--- a/packages/lang-java/package.json
+++ b/packages/lang-java/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@ctxo/lang-java",
+  "version": "0.8.0",
+  "description": "Ctxo Java language plugin (tree-sitter, syntax tier)",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:unit": "vitest run"
+  },
+  "keywords": [
+    "ctxo",
+    "ctxo-plugin",
+    "language-plugin",
+    "java",
+    "tree-sitter"
+  ],
+  "author": "Alper Hankendi",
+  "license": "MIT",
+  "dependencies": {
+    "tree-sitter": "^0.22.4",
+    "tree-sitter-java": "^0.23.5"
+  },
+  "peerDependencies": {
+    "@ctxo/plugin-api": "^0.7.1"
+  },
+  "devDependencies": {
+    "@ctxo/plugin-api": "workspace:*",
+    "@types/node": "^22.15.3",
+    "tsup": "^8.4.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alperhankendi/Ctxo.git",
+    "directory": "packages/lang-java"
+  },
+  "bugs": {
+    "url": "https://github.com/alperhankendi/Ctxo/issues"
+  },
+  "homepage": "https://github.com/alperhankendi/Ctxo#readme",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/lang-java/src/__tests__/fixtures/Payment.java.fixture
+++ b/packages/lang-java/src/__tests__/fixtures/Payment.java.fixture
@@ -1,0 +1,53 @@
+package com.example.payment;
+
+import java.util.List;
+import java.util.Optional;
+import com.example.gateway.Gateway;
+
+public interface Processor {
+    PaymentResult process(double amount);
+}
+
+class PaymentResult {
+    public boolean success;
+    public String message;
+
+    public PaymentResult(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+}
+
+public class CardProcessor implements Processor {
+    private final Gateway gateway;
+
+    public CardProcessor(Gateway gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public PaymentResult process(double amount) {
+        if (amount <= 0) {
+            return new PaymentResult(false, "invalid");
+        }
+        for (int i = 0; i < 3; i++) {
+            try {
+                gateway.charge(amount);
+                return new PaymentResult(true, "ok");
+            } catch (RuntimeException e) {
+                if (i == 2) throw e;
+            }
+        }
+        return new PaymentResult(false, "retry-exhausted");
+    }
+
+    public static String formatAmount(double amount) {
+        return amount > 0 && amount < 1000 ? "$" + amount : "out-of-range";
+    }
+}
+
+class PremiumProcessor extends CardProcessor {
+    public PremiumProcessor(Gateway gateway) {
+        super(gateway);
+    }
+}

--- a/packages/lang-java/src/__tests__/java-adapter.test.ts
+++ b/packages/lang-java/src/__tests__/java-adapter.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { JavaAdapter } from '../java-adapter.js';
+
+const FIXTURES_DIR = join(import.meta.dirname, 'fixtures');
+
+function readFixture(name: string): string {
+  return readFileSync(join(FIXTURES_DIR, name), 'utf-8');
+}
+
+describe('JavaAdapter — symbol extraction', () => {
+  const adapter = new JavaAdapter();
+
+  it('extracts public class as class kind', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const symbols = await adapter.extractSymbols('src/Payment.java', source);
+
+    const cls = symbols.find((s) => s.name === 'CardProcessor');
+    expect(cls).toBeDefined();
+    expect(cls!.kind).toBe('class');
+    expect(cls!.symbolId).toBe('src/Payment.java::CardProcessor::class');
+  });
+
+  it('extracts package-private class', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const symbols = await adapter.extractSymbols('src/Payment.java', source);
+
+    const cls = symbols.find((s) => s.name === 'PaymentResult');
+    expect(cls).toBeDefined();
+    expect(cls!.kind).toBe('class');
+  });
+
+  it('extracts interface as interface kind', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const symbols = await adapter.extractSymbols('src/Payment.java', source);
+
+    const iface = symbols.find((s) => s.name === 'Processor');
+    expect(iface).toBeDefined();
+    expect(iface!.kind).toBe('interface');
+  });
+
+  it('qualifies method names with enclosing type', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const symbols = await adapter.extractSymbols('src/Payment.java', source);
+
+    const method = symbols.find((s) => s.name === 'CardProcessor.process');
+    expect(method).toBeDefined();
+    expect(method!.kind).toBe('method');
+    expect(method!.symbolId).toBe('src/Payment.java::CardProcessor.process::method');
+  });
+
+  it('extracts static method', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const symbols = await adapter.extractSymbols('src/Payment.java', source);
+
+    const method = symbols.find((s) => s.name === 'CardProcessor.formatAmount');
+    expect(method).toBeDefined();
+    expect(method!.kind).toBe('method');
+  });
+
+  it('extracts constructor as method named ClassName.ClassName', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const symbols = await adapter.extractSymbols('src/Payment.java', source);
+
+    const ctor = symbols.find((s) => s.name === 'CardProcessor.CardProcessor');
+    expect(ctor).toBeDefined();
+    expect(ctor!.kind).toBe('method');
+  });
+
+  it('includes byte offsets on all symbols', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const symbols = await adapter.extractSymbols('src/Payment.java', source);
+
+    for (const sym of symbols) {
+      expect(sym.startOffset).toBeDefined();
+      expect(sym.endOffset).toBeDefined();
+      expect(sym.startOffset).toBeLessThan(sym.endOffset!);
+    }
+  });
+
+  it('extracts enum as class kind', async () => {
+    const source = `package x;
+public enum Status { OK, FAIL }
+`;
+    const symbols = await adapter.extractSymbols('src/Status.java', source);
+    const e = symbols.find((s) => s.name === 'Status');
+    expect(e).toBeDefined();
+    expect(e!.kind).toBe('class');
+  });
+
+  it('extracts record as class kind', async () => {
+    const source = `package x;
+public record Point(int x, int y) {}
+`;
+    const symbols = await adapter.extractSymbols('src/Point.java', source);
+    const r = symbols.find((s) => s.name === 'Point');
+    expect(r).toBeDefined();
+    expect(r!.kind).toBe('class');
+  });
+
+  it('qualifies nested class name with outer class', async () => {
+    const source = `package x;
+public class Outer {
+    public static class Inner {
+        public void run() {}
+    }
+}
+`;
+    const symbols = await adapter.extractSymbols('src/Outer.java', source);
+    const inner = symbols.find((s) => s.name === 'Outer.Inner');
+    expect(inner).toBeDefined();
+    expect(inner!.kind).toBe('class');
+    const innerMethod = symbols.find((s) => s.name === 'Outer.Inner.run');
+    expect(innerMethod).toBeDefined();
+    expect(innerMethod!.kind).toBe('method');
+  });
+});
+
+describe('JavaAdapter — edge extraction', () => {
+  const adapter = new JavaAdapter();
+
+  it('extracts import edges anchored on the first declared type', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const edges = await adapter.extractEdges('src/Payment.java', source);
+
+    const importEdges = edges.filter((e) => e.kind === 'imports');
+    expect(importEdges.length).toBeGreaterThanOrEqual(3);
+    expect(importEdges.some((e) => e.to.startsWith('java.util.List'))).toBe(true);
+    expect(importEdges.some((e) => e.to.startsWith('com.example.gateway.Gateway'))).toBe(true);
+    // The first declared top-level type in the fixture is the Processor interface.
+    expect(importEdges[0]!.from).toBe('src/Payment.java::Processor::interface');
+  });
+
+  it('emits name-keyed import targets (no __unresolved__ sentinel)', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const edges = await adapter.extractEdges('src/Payment.java', source);
+    for (const e of edges) {
+      expect(e.to).not.toMatch(/^__unresolved__::/);
+    }
+  });
+
+  it('skips wildcard imports (no actionable target)', async () => {
+    const source = `package x;
+import java.util.*;
+public class A {}
+`;
+    const edges = await adapter.extractEdges('src/A.java', source);
+    const wildcards = edges.filter((e) => e.kind === 'imports' && e.to.includes('*'));
+    expect(wildcards).toEqual([]);
+  });
+
+  it('normalizes static member imports to the enclosing class', async () => {
+    const source = `package x;
+import static java.lang.Math.PI;
+public class A {}
+`;
+    const edges = await adapter.extractEdges('src/A.java', source);
+    const importEdge = edges.find((e) => e.kind === 'imports');
+    expect(importEdge).toBeDefined();
+    // Should resolve to the enclosing class, not the member.
+    expect(importEdge!.to).toMatch(/^java\.lang\.Math::Math::class$/);
+  });
+
+  it('extracts implements edges for class implements interface', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const edges = await adapter.extractEdges('src/Payment.java', source);
+
+    const impl = edges.find(
+      (e) => e.kind === 'implements' && e.from.includes('CardProcessor') && e.to.endsWith('::Processor::interface'),
+    );
+    expect(impl).toBeDefined();
+  });
+
+  it('extracts extends edge for class extends class', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const edges = await adapter.extractEdges('src/Payment.java', source);
+
+    const ext = edges.find(
+      (e) => e.kind === 'extends' && e.from.includes('PremiumProcessor') && e.to.endsWith('::CardProcessor::class'),
+    );
+    expect(ext).toBeDefined();
+  });
+
+  it('treats interface extends as extends edge', async () => {
+    const source = `package x;
+public interface A {}
+public interface B extends A {}
+`;
+    const edges = await adapter.extractEdges('src/A.java', source);
+    const ext = edges.find((e) => e.kind === 'extends' && e.from.includes('::B::') && e.to.endsWith('::A::interface'));
+    expect(ext).toBeDefined();
+  });
+
+  it('strips generic parameters from extends/implements targets', async () => {
+    const source = `package x;
+public class A<T> {}
+public class B extends A<String> {}
+`;
+    const edges = await adapter.extractEdges('src/A.java', source);
+    const ext = edges.find((e) => e.kind === 'extends' && e.from.includes('::B::'));
+    expect(ext).toBeDefined();
+    expect(ext!.to).toBe('A::A::class');
+  });
+
+  it('uses cross-file symbol registry to resolve extends to the real symbol id', async () => {
+    const registry = new Map([
+      ['src/Discount.java::Discount::interface', 'interface' as const],
+    ]);
+    adapter.setSymbolRegistry(registry);
+    const source = `package x;
+public class PercentageDiscount implements Discount {}
+`;
+    const edges = await adapter.extractEdges('src/PercentageDiscount.java', source);
+    const impl = edges.find((e) => e.kind === 'implements');
+    expect(impl).toBeDefined();
+    expect(impl!.to).toBe('src/Discount.java::Discount::interface');
+    // Reset registry for downstream tests.
+    adapter.setSymbolRegistry(new Map());
+  });
+
+  it('returns no import edges when file has no top-level type', async () => {
+    const source = `package x;
+import java.util.List;
+`;
+    const edges = await adapter.extractEdges('src/empty.java', source);
+    expect(edges.filter((e) => e.kind === 'imports')).toEqual([]);
+  });
+});
+
+describe('JavaAdapter — complexity extraction', () => {
+  const adapter = new JavaAdapter();
+
+  it('returns complexity 1 for method with no branches', async () => {
+    const source = `package x;
+public class Simple {
+    public int answer() { return 42; }
+}
+`;
+    const metrics = await adapter.extractComplexity('src/Simple.java', source);
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0]!.cyclomatic).toBe(1);
+  });
+
+  it('counts if/for/catch branches in process()', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const metrics = await adapter.extractComplexity('src/Payment.java', source);
+
+    const m = metrics.find((x) => x.symbolId.includes('CardProcessor.process'));
+    expect(m).toBeDefined();
+    // 1 base + if + nested-if + for + catch = at least 5
+    expect(m!.cyclomatic).toBeGreaterThanOrEqual(4);
+  });
+
+  it('counts && / || short-circuits and ternary', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const metrics = await adapter.extractComplexity('src/Payment.java', source);
+
+    const m = metrics.find((x) => x.symbolId.includes('CardProcessor.formatAmount'));
+    expect(m).toBeDefined();
+    // 1 base + 1 ternary + 1 `&&` = 3
+    expect(m!.cyclomatic).toBeGreaterThanOrEqual(3);
+  });
+
+  it('emits complexity for constructors', async () => {
+    const source = readFixture('Payment.java.fixture');
+    const metrics = await adapter.extractComplexity('src/Payment.java', source);
+
+    const m = metrics.find((x) => x.symbolId.includes('CardProcessor.CardProcessor'));
+    expect(m).toBeDefined();
+    expect(m!.cyclomatic).toBe(1);
+  });
+});
+
+describe('JavaAdapter — isSupported', () => {
+  const adapter = new JavaAdapter();
+
+  it('returns true for .java files', () => {
+    expect(adapter.isSupported('src/Foo.java')).toBe(true);
+  });
+
+  it('is case-insensitive on extension', () => {
+    expect(adapter.isSupported('src/Foo.JAVA')).toBe(true);
+  });
+
+  it('returns false for non-java files', () => {
+    expect(adapter.isSupported('src/main.go')).toBe(false);
+    expect(adapter.isSupported('src/main.ts')).toBe(false);
+    expect(adapter.isSupported('src/main.kt')).toBe(false);
+  });
+
+  it('has syntax tier', () => {
+    expect(adapter.tier).toBe('syntax');
+  });
+});
+
+describe('JavaAdapter plugin export', () => {
+  it('declares correct plugin metadata', async () => {
+    const mod = await import('../index.js');
+    expect(mod.plugin.id).toBe('java');
+    expect(mod.plugin.apiVersion).toBe('1');
+    expect(mod.plugin.tier).toBe('syntax');
+    expect(mod.plugin.extensions).toEqual(['.java']);
+  });
+});

--- a/packages/lang-java/src/index.ts
+++ b/packages/lang-java/src/index.ts
@@ -1,0 +1,21 @@
+import type { CtxoLanguagePlugin, PluginContext, ILanguageAdapter } from '@ctxo/plugin-api';
+import { JavaAdapter } from './java-adapter.js';
+
+export { JavaAdapter } from './java-adapter.js';
+export { TreeSitterAdapter } from './tree-sitter-adapter.js';
+
+const VERSION = '0.8.0';
+
+export const plugin: CtxoLanguagePlugin = {
+  apiVersion: '1',
+  id: 'java',
+  name: 'Java (tree-sitter)',
+  version: VERSION,
+  extensions: ['.java'],
+  tier: 'syntax',
+  createAdapter(_ctx: PluginContext): ILanguageAdapter {
+    return new JavaAdapter();
+  },
+};
+
+export default plugin;

--- a/packages/lang-java/src/java-adapter.ts
+++ b/packages/lang-java/src/java-adapter.ts
@@ -1,0 +1,401 @@
+import JavaLanguage from 'tree-sitter-java';
+import type { SyntaxNode } from 'tree-sitter';
+import { TreeSitterAdapter } from './tree-sitter-adapter.js';
+import { createLogger } from './logger.js';
+import type { SymbolNode, GraphEdge, ComplexityMetrics, SymbolKind } from '@ctxo/plugin-api';
+
+const log = createLogger('ctxo:lang-java');
+
+/**
+ * Tree-sitter node types that increment cyclomatic complexity.
+ * `&&` and `||` short-circuit operators are handled in the base class.
+ */
+const JAVA_BRANCH_TYPES = [
+  'if_statement',
+  'for_statement',
+  'enhanced_for_statement',
+  'while_statement',
+  'do_statement',
+  'switch_label',
+  'catch_clause',
+  'ternary_expression',
+];
+
+/** Top-level type-like declarations that own a method namespace. */
+const TYPE_DECLARATIONS = new Set([
+  'class_declaration',
+  'interface_declaration',
+  'enum_declaration',
+  'record_declaration',
+]);
+
+export class JavaAdapter extends TreeSitterAdapter {
+  readonly extensions = ['.java'] as const;
+
+  constructor() {
+    super(JavaLanguage);
+  }
+
+  async extractSymbols(filePath: string, source: string): Promise<SymbolNode[]> {
+    try {
+      const tree = this.parse(source);
+      const symbols: SymbolNode[] = [];
+      this.walkTypes(tree.rootNode, filePath, symbols, []);
+      return symbols;
+    } catch (err) {
+      log.error(`Symbol extraction failed for ${filePath}: ${(err as Error).message}`);
+      return [];
+    }
+  }
+
+  async extractEdges(filePath: string, source: string): Promise<GraphEdge[]> {
+    try {
+      const tree = this.parse(source);
+      const edges: GraphEdge[] = [];
+
+      const firstType = this.findFirstTypeSymbolId(tree.rootNode, filePath);
+
+      // Imports: anchored on the first declared top-level type.
+      // Files with no top-level type (e.g. `package-info.java`) have no anchor;
+      // imports edges are skipped in that case (mirrors lang-go's behavior).
+      for (let i = 0; i < tree.rootNode.childCount; i++) {
+        const node = tree.rootNode.child(i)!;
+        if (node.type === 'import_declaration' && firstType) {
+          const importEdge = this.buildImportEdge(node, firstType);
+          if (importEdge) edges.push(importEdge);
+        }
+      }
+
+      // extends / implements edges per type declaration.
+      this.walkTypeRelations(tree.rootNode, filePath, edges, []);
+
+      return edges;
+    } catch (err) {
+      log.error(`Edge extraction failed for ${filePath}: ${(err as Error).message}`);
+      return [];
+    }
+  }
+
+  async extractComplexity(filePath: string, source: string): Promise<ComplexityMetrics[]> {
+    try {
+      const tree = this.parse(source);
+      const metrics: ComplexityMetrics[] = [];
+      this.walkMethods(tree.rootNode, filePath, [], (qualifiedName, kind, methodNode) => {
+        metrics.push({
+          symbolId: this.buildSymbolId(filePath, qualifiedName, kind),
+          cyclomatic: this.countCyclomaticComplexity(methodNode, JAVA_BRANCH_TYPES),
+        });
+      });
+      return metrics;
+    } catch (err) {
+      log.error(`Complexity extraction failed for ${filePath}: ${(err as Error).message}`);
+      return [];
+    }
+  }
+
+  // ── Private helpers ─────────────────────────────────────────
+
+  private typeKindFor(nodeType: string): SymbolKind {
+    switch (nodeType) {
+      case 'interface_declaration':
+        return 'interface';
+      case 'class_declaration':
+      case 'enum_declaration':
+      case 'record_declaration':
+      default:
+        return 'class';
+    }
+  }
+
+  /**
+   * Recursively visit type-like declarations (including nested types) and
+   * record their symbols plus contained methods/constructors.
+   *
+   * `enclosing` is the chain of outer type names, used to qualify nested
+   * type and method names: `Outer.Inner`, `Outer.Inner.method`.
+   */
+  private walkTypes(
+    node: SyntaxNode,
+    filePath: string,
+    out: SymbolNode[],
+    enclosing: string[],
+  ): void {
+    if (TYPE_DECLARATIONS.has(node.type)) {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        const qualified = [...enclosing, name].join('.');
+        const kind = this.typeKindFor(node.type);
+        const range = this.nodeToLineRange(node);
+        out.push({
+          symbolId: this.buildSymbolId(filePath, qualified, kind),
+          name: qualified,
+          kind,
+          ...range,
+        });
+
+        // Methods and constructors inside this type.
+        const body = node.childForFieldName('body');
+        if (body) {
+          for (let i = 0; i < body.childCount; i++) {
+            const member = body.child(i)!;
+            if (member.type === 'method_declaration') {
+              const methodName = member.childForFieldName('name')?.text;
+              if (!methodName) continue;
+              const qname = `${qualified}.${methodName}`;
+              const r = this.nodeToLineRange(member);
+              out.push({
+                symbolId: this.buildSymbolId(filePath, qname, 'method'),
+                name: qname,
+                kind: 'method',
+                ...r,
+              });
+            } else if (member.type === 'constructor_declaration') {
+              // Constructor name is the same as the enclosing class name.
+              const ctorName = `${qualified}.${name}`;
+              const r = this.nodeToLineRange(member);
+              out.push({
+                symbolId: this.buildSymbolId(filePath, ctorName, 'method'),
+                name: ctorName,
+                kind: 'method',
+                ...r,
+              });
+            } else if (TYPE_DECLARATIONS.has(member.type)) {
+              this.walkTypes(member, filePath, out, [...enclosing, name]);
+            }
+          }
+        }
+        return;
+      }
+    }
+
+    for (let i = 0; i < node.childCount; i++) {
+      this.walkTypes(node.child(i)!, filePath, out, enclosing);
+    }
+  }
+
+  /**
+   * Yield every method/constructor with its qualified name and kind so callers
+   * can produce per-symbol records (e.g. complexity metrics).
+   */
+  private walkMethods(
+    node: SyntaxNode,
+    filePath: string,
+    enclosing: string[],
+    visit: (qualifiedName: string, kind: SymbolKind, methodNode: SyntaxNode) => void,
+  ): void {
+    if (TYPE_DECLARATIONS.has(node.type)) {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        const qualified = [...enclosing, name].join('.');
+        const body = node.childForFieldName('body');
+        if (body) {
+          for (let i = 0; i < body.childCount; i++) {
+            const member = body.child(i)!;
+            if (member.type === 'method_declaration') {
+              const methodName = member.childForFieldName('name')?.text;
+              if (methodName) {
+                visit(`${qualified}.${methodName}`, 'method', member);
+              }
+            } else if (member.type === 'constructor_declaration') {
+              visit(`${qualified}.${name}`, 'method', member);
+            } else if (TYPE_DECLARATIONS.has(member.type)) {
+              this.walkMethods(member, filePath, [...enclosing, name], visit);
+            }
+          }
+        }
+        return;
+      }
+    }
+    for (let i = 0; i < node.childCount; i++) {
+      this.walkMethods(node.child(i)!, filePath, enclosing, visit);
+    }
+  }
+
+  /** Emit `extends`/`implements` edges for each top-level or nested type. */
+  private walkTypeRelations(
+    node: SyntaxNode,
+    filePath: string,
+    edges: GraphEdge[],
+    enclosing: string[],
+  ): void {
+    if (TYPE_DECLARATIONS.has(node.type)) {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        const qualified = [...enclosing, name].join('.');
+        const kind = this.typeKindFor(node.type);
+        const fromId = this.buildSymbolId(filePath, qualified, kind);
+
+        // class extends Foo
+        const superclass = node.childForFieldName('superclass');
+        if (superclass) {
+          for (const typeName of this.typeNamesIn(superclass)) {
+            edges.push({
+              from: fromId,
+              to: this.resolveTypeTarget(typeName, 'class'),
+              kind: 'extends',
+            });
+          }
+        }
+
+        // class implements Foo, Bar
+        const interfaces = node.childForFieldName('interfaces');
+        if (interfaces) {
+          for (const typeName of this.typeNamesIn(interfaces)) {
+            edges.push({
+              from: fromId,
+              to: this.resolveTypeTarget(typeName, 'interface'),
+              kind: 'implements',
+            });
+          }
+        }
+
+        // interface extends Foo, Bar  (tree-sitter exposes this as a child
+        // node of type `extends_interfaces`, not a labeled field).
+        if (node.type === 'interface_declaration') {
+          for (let i = 0; i < node.childCount; i++) {
+            const c = node.child(i)!;
+            if (c.type === 'extends_interfaces') {
+              for (const typeName of this.typeNamesIn(c)) {
+                edges.push({
+                  from: fromId,
+                  to: this.resolveTypeTarget(typeName, 'interface'),
+                  kind: 'extends',
+                });
+              }
+            }
+          }
+        }
+
+        // Recurse into the body to capture nested types.
+        const body = node.childForFieldName('body');
+        if (body) {
+          for (let i = 0; i < body.childCount; i++) {
+            const member = body.child(i)!;
+            if (TYPE_DECLARATIONS.has(member.type)) {
+              this.walkTypeRelations(member, filePath, edges, [...enclosing, name]);
+            }
+          }
+        }
+        return;
+      }
+    }
+
+    for (let i = 0; i < node.childCount; i++) {
+      this.walkTypeRelations(node.child(i)!, filePath, edges, enclosing);
+    }
+  }
+
+  private typeNamesIn(node: SyntaxNode): string[] {
+    const out: string[] = [];
+    const visit = (n: SyntaxNode) => {
+      if (n.type === 'type_identifier' || n.type === 'scoped_type_identifier') {
+        out.push(n.text);
+        return;
+      }
+      for (let i = 0; i < n.childCount; i++) {
+        visit(n.child(i)!);
+      }
+    };
+    visit(node);
+    return out;
+  }
+
+  /**
+   * Build an `imports` edge from an import_declaration node, anchored at
+   * `fromId`. Returns `undefined` when the import does not point to a
+   * resolvable type target (currently: wildcard imports `import x.*;`).
+   *
+   * Static imports of members (`import static java.lang.Math.PI;`) are
+   * normalized to the enclosing class (`java.lang.Math`).
+   */
+  private buildImportEdge(importDecl: SyntaxNode, fromId: string): GraphEdge | undefined {
+    let target: string | undefined;
+    let isStatic = false;
+    let isWildcard = false;
+
+    for (let i = 0; i < importDecl.childCount; i++) {
+      const c = importDecl.child(i)!;
+      if (c.type === 'static') isStatic = true;
+      if (c.type === 'asterisk' || c.text === '*') isWildcard = true;
+      if (c.type === 'scoped_identifier' || c.type === 'identifier') {
+        target = c.text;
+      }
+    }
+
+    if (!target) return undefined;
+
+    // Wildcard imports (`import x.y.*;`) carry no specific target — skip.
+    if (isWildcard) return undefined;
+
+    // Static member import: drop trailing member to point at the enclosing class.
+    // `java.lang.Math.PI` → `java.lang.Math`
+    let resolvedTarget = target;
+    if (isStatic) {
+      const lastDot = target.lastIndexOf('.');
+      if (lastDot > 0) resolvedTarget = target.slice(0, lastDot);
+    }
+
+    const baseName = resolvedTarget.split('.').pop()!;
+    return {
+      from: fromId,
+      to: this.resolveImportTarget(resolvedTarget, baseName),
+      kind: 'imports',
+    };
+  }
+
+  /**
+   * Resolve a referenced type to a concrete symbol ID.
+   *
+   * Strategy mirrors `lang-csharp` — walk the cross-file `symbolRegistry`
+   * (populated by the indexer in pass 1) for any symbol whose ID ends with
+   * `::TypeName::kind`. Falls back to a name-keyed ID `Name::Name::kind`
+   * which the SymbolGraph fuzzy resolver can still grep against later.
+   */
+  private resolveTypeTarget(typeName: string, defaultKind: SymbolKind): string {
+    // Strip generic args (`Foo<Bar>` → `Foo`)
+    const bare = typeName.replace(/<.*$/, '').trim();
+    if (this.symbolRegistry.size > 0) {
+      for (const [id] of this.symbolRegistry) {
+        if (id.endsWith(`::${bare}::class`) || id.endsWith(`::${bare}::interface`)) {
+          return id;
+        }
+      }
+    }
+    return `${bare}::${bare}::${defaultKind}`;
+  }
+
+  /**
+   * Resolve an import target (dotted package path) to a concrete symbol ID.
+   * Same fallback strategy as {@link resolveTypeTarget} but anchored on the
+   * trailing package segment.
+   */
+  private resolveImportTarget(qualifiedName: string, baseName: string): string {
+    if (this.symbolRegistry.size > 0) {
+      for (const [id] of this.symbolRegistry) {
+        if (id.endsWith(`::${baseName}::class`) || id.endsWith(`::${baseName}::interface`)) {
+          return id;
+        }
+      }
+    }
+    return `${qualifiedName}::${baseName}::class`;
+  }
+
+  private findFirstTypeSymbolId(rootNode: SyntaxNode, filePath: string): string | undefined {
+    let found: string | undefined;
+    const visit = (n: SyntaxNode): boolean => {
+      if (TYPE_DECLARATIONS.has(n.type)) {
+        const name = n.childForFieldName('name')?.text;
+        if (name) {
+          found = this.buildSymbolId(filePath, name, this.typeKindFor(n.type));
+          return true;
+        }
+      }
+      for (let i = 0; i < n.childCount; i++) {
+        if (visit(n.child(i)!)) return true;
+      }
+      return false;
+    };
+    visit(rootNode);
+    return found;
+  }
+}

--- a/packages/lang-java/src/logger.ts
+++ b/packages/lang-java/src/logger.ts
@@ -1,0 +1,38 @@
+/**
+ * Minimal namespaced logger. Mirrors the shape used by sibling lang plugins.
+ * Emits to stderr only (stdio transport requires stdout kept clean).
+ */
+type LogFn = (message: string, ...args: unknown[]) => void;
+
+export interface Logger {
+  debug: LogFn;
+  info: LogFn;
+  warn: LogFn;
+  error: LogFn;
+}
+
+function enabledFor(namespace: string): boolean {
+  const env = process.env['DEBUG'];
+  if (!env) return false;
+  const patterns = env.split(',').map((p) => p.trim()).filter(Boolean);
+  for (const pattern of patterns) {
+    if (pattern === '*' || pattern === namespace) return true;
+    if (pattern.endsWith('*') && namespace.startsWith(pattern.slice(0, -1))) return true;
+  }
+  return false;
+}
+
+function emit(namespace: string, level: string, message: string, args: unknown[]): void {
+  const line = `[${namespace}] ${message}${args.length ? ' ' + args.map(String).join(' ') : ''}`;
+  if (level === 'error' || level === 'warn') process.stderr.write(line + '\n');
+  else if (enabledFor(namespace)) process.stderr.write(line + '\n');
+}
+
+export function createLogger(namespace: string): Logger {
+  return {
+    debug: (msg, ...args) => emit(namespace, 'debug', msg, args),
+    info: (msg, ...args) => emit(namespace, 'info', msg, args),
+    warn: (msg, ...args) => emit(namespace, 'warn', msg, args),
+    error: (msg, ...args) => emit(namespace, 'error', msg, args),
+  };
+}

--- a/packages/lang-java/src/tree-sitter-adapter.ts
+++ b/packages/lang-java/src/tree-sitter-adapter.ts
@@ -1,0 +1,77 @@
+import Parser from 'tree-sitter';
+import type { Tree, SyntaxNode } from 'tree-sitter';
+// Grammars (tree-sitter-java etc.) ship their own Language type which can drift
+// against tree-sitter's parameter type across major versions. Accept any
+// structurally compatible value and hand it to the parser as the runtime API
+// expects (the parser does its own validation).
+type Language = Parameters<InstanceType<typeof Parser>['setLanguage']>[0] | object;
+import { extname } from 'node:path';
+import type { SymbolNode, GraphEdge, ComplexityMetrics, SymbolKind, ILanguageAdapter } from '@ctxo/plugin-api';
+
+export abstract class TreeSitterAdapter implements ILanguageAdapter {
+  abstract readonly extensions: readonly string[];
+  readonly tier = 'syntax' as const;
+
+  protected parser: Parser;
+  protected symbolRegistry = new Map<string, SymbolKind>();
+
+  constructor(language: Language) {
+    this.parser = new Parser();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.parser.setLanguage(language as any);
+  }
+
+  isSupported(filePath: string): boolean {
+    const ext = extname(filePath).toLowerCase();
+    return (this.extensions as readonly string[]).includes(ext);
+  }
+
+  setSymbolRegistry(registry: Map<string, SymbolKind>): void {
+    this.symbolRegistry = registry;
+  }
+
+  protected parse(source: string): Tree {
+    return this.parser.parse(source);
+  }
+
+  protected buildSymbolId(filePath: string, name: string, kind: SymbolKind): string {
+    return `${filePath}::${name}::${kind}`;
+  }
+
+  protected nodeToLineRange(node: SyntaxNode): {
+    startLine: number;
+    endLine: number;
+    startOffset: number;
+    endOffset: number;
+  } {
+    return {
+      startLine: node.startPosition.row,
+      endLine: node.endPosition.row,
+      startOffset: node.startIndex,
+      endOffset: node.endIndex,
+    };
+  }
+
+  protected countCyclomaticComplexity(node: SyntaxNode, branchTypes: string[]): number {
+    let complexity = 1;
+    const visit = (n: SyntaxNode) => {
+      if (branchTypes.includes(n.type)) {
+        complexity++;
+      }
+      // Treat `&&` and `||` operators inside binary_expression as branches.
+      if (n.type === 'binary_expression') {
+        const op = n.children.find((c) => c.type === '&&' || c.type === '||');
+        if (op) complexity++;
+      }
+      for (let i = 0; i < n.childCount; i++) {
+        visit(n.child(i)!);
+      }
+    };
+    visit(node);
+    return complexity;
+  }
+
+  abstract extractSymbols(filePath: string, source: string): Promise<SymbolNode[]>;
+  abstract extractEdges(filePath: string, source: string): Promise<GraphEdge[]>;
+  abstract extractComplexity(filePath: string, source: string): Promise<ComplexityMetrics[]>;
+}

--- a/packages/lang-java/tsconfig.json
+++ b/packages/lang-java/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/__tests__/**"]
+}

--- a/packages/lang-java/tsup.config.ts
+++ b/packages/lang-java/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: 'node20',
+  external: ['@ctxo/plugin-api', 'tree-sitter', 'tree-sitter-java'],
+});

--- a/packages/lang-java/vitest.config.ts
+++ b/packages/lang-java/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/__tests__/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,31 @@ importers:
         specifier: ^3.1.3
         version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/lang-java:
+    dependencies:
+      tree-sitter:
+        specifier: ^0.22.4
+        version: 0.22.4
+      tree-sitter-java:
+        specifier: ^0.23.5
+        version: 0.23.5(tree-sitter@0.22.4)
+    devDependencies:
+      '@ctxo/plugin-api':
+        specifier: workspace:*
+        version: link:../plugin-api
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.19.17
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.3
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/lang-typescript:
     dependencies:
       ts-morph:
@@ -2539,6 +2564,14 @@ packages:
 
   tree-sitter-go@0.23.4:
     resolution: {integrity: sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-java@0.23.5:
+    resolution: {integrity: sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==}
     peerDependencies:
       tree-sitter: ^0.21.1
     peerDependenciesMeta:
@@ -5248,6 +5281,13 @@ snapshots:
       tree-sitter: 0.22.4
 
   tree-sitter-go@0.23.4(tree-sitter@0.22.4):
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
+
+  tree-sitter-java@0.23.5(tree-sitter@0.22.4):
     dependencies:
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4

--- a/site/docs/languages/overview.md
+++ b/site/docs/languages/overview.md
@@ -19,6 +19,7 @@ runtime dependencies on `@ctxo/cli`.
 | TypeScript/JavaScript | `@ctxo/lang-typescript` | ts-morph                                         | `full`   | `.ts .tsx .js .jsx`        |
 | Go                    | `@ctxo/lang-go`         | `ctxo-go-analyzer` (Go 1.22+) + tree-sitter-go   | `full`   | `.go`                      |
 | C#                    | `@ctxo/lang-csharp`     | `ctxo-roslyn` (.NET SDK 8+) + tree-sitter-c-sharp | `full`  | `.cs`                      |
+| Java                  | `@ctxo/lang-java`       | tree-sitter-java                                 | `syntax` | `.java`                    |
 
 Two tiers are defined by the plugin contract:
 


### PR DESCRIPTION
## Summary

Adds `@ctxo/lang-java` — a Java language plugin built on `tree-sitter-java`, scoped to `tier: 'syntax'`. Detection wiring (`pom.xml`, `build.gradle`, `build.gradle.kts`, `.java`) was already in place in `@ctxo/cli`, so no CLI changes are needed.

## Coverage

- **Symbols**: classes, interfaces, enums, records, methods, constructors. Nested types are dotted-qualified (`Outer.Inner`); methods are qualified by enclosing type (`Outer.method`); constructors as `ClassName.ClassName`.
- **Edges**: `imports` (with wildcard skip and static-import normalization), `extends`, `implements` (including `interface extends`). Edge targets are name-keyed and resolved against the cross-file symbol registry — same convention as `@ctxo/lang-csharp`, so `SymbolGraph.resolveNodeId` binds them to real symbols on indexed targets.
- **Cyclomatic complexity**: counts `if`, `for`, `enhanced_for`, `while`, `do`, `switch_label`, `catch_clause`, `ternary_expression`, plus `&&`/`||` short-circuit operators.

## Validation

- **29/29 unit tests** pass (covers symbol kinds, nested types, constructors, generics, registry-resolution, wildcard-import skip, static-import normalization, regression test for `__unresolved__` sentinel removal)
- **E2E demo** on a 3-file Maven project (`pom.xml` + 3 `.java` files): `implements` edge from `PercentageDiscount` resolves to `src/main/java/com/example/shop/Discount.java::Discount::interface` — verified by joining `edges → symbols` in the SQLite cache. No dangling targets.
- `pnpm typecheck` clean; `pnpm build` produces `dist/index.js` (13.7 KB) + `dist/index.d.ts` (3.5 KB)

## Test plan

- [ ] CI green (lint, typecheck, vitest, build)
- [ ] Reviewer can clone a Maven/Gradle project, run `npm install -D @ctxo/lang-java`, then `ctxo init` + `ctxo index`
- [ ] SQLite cache shows resolved `extends`/`implements` edges (no `__unresolved__::` sentinel anywhere)

## Out of scope (tracked as separate follow-up issues)

- #69 — `full` tier (JDT/javac analyzer) for resolved `calls`/`uses` edges
- #70 — `@ctxo/plugin-api`: extend `SymbolKind`/`EdgeKind` to support sealed `permits`, enum constants with bodies, initializer blocks, anonymous inner classes
- #71 — `doctor` `language-coverage-check.ts` resolver bug (pre-existing, not Java-specific): surfaces as a spurious `missing plugins for: java` warning even when the plugin loads correctly
- #72 — Promote `TreeSitterAdapter` and namespaced logger to a shared package (lang-go, lang-csharp, lang-java duplicate them today)
- #73 — Remove hardcoded language tables in `runtime-check.ts` and `index-command.ts`

## Process notes

- Added a changeset (`.changeset/add-lang-java.md`) for a `minor` bump on `@ctxo/lang-java`
- Version `0.8.0` to align with sibling plugins (`@ctxo/lang-go@0.8.0`, `@ctxo/lang-csharp@0.7.2`, `@ctxo/lang-typescript@0.7.1`)
- `peerDependencies: { "@ctxo/plugin-api": "^0.7.1" }` matches siblings
- Updated `site/docs/languages/overview.md` support matrix with the Java row
- A new `packages/lang-java/README.md` documents coverage, edge encoding, and the known limitations from the follow-up issues

## Review process

This PR went through three rounds of internal review focused on (a) contract compliance vs. siblings, (b) empirical end-to-end edge resolution, and (c) ecosystem integration. The first draft used an `__unresolved__::Name::kind` sentinel for unresolved edge targets — reviewers showed this never matches `SymbolGraph.resolveNodeId`'s fuzzy lookup. The current encoding mirrors `@ctxo/lang-csharp`'s registry-walk fallback and was verified end-to-end against the demo SQLite (one cross-file `implements` edge, RESOLVED).