### PR TITLE
feat(cli): add Gemini CLI and Continue to ctxo init

### DIFF
--- a/.changeset/init-gemini-cli-continue.md
+++ b/.changeset/init-gemini-cli-continue.md
@@ -1,0 +1,10 @@
+---
+'@ctxo/cli': patch
+---
+
+`ctxo init` now supports **Gemini CLI** and **Continue** as installable AI tool targets, bringing the supported tool list to nine.
+
+- **Gemini CLI**: appends a marked rules block to `GEMINI.md` at the repo root and registers the ctxo MCP server at `.gemini/settings.json` (`mcpServers` key, same schema as Claude Code / Cursor).
+- **Continue**: writes `.continue/rules/ctxo.md` and registers the MCP server as a standalone file at `.continue/mcpServers/ctxo.json` (Continue picks up each file in that directory separately).
+
+Run `ctxo init` and pick `gemini-cli` and/or `continue` from the interactive list, or use `ctxo init --tools gemini-cli,continue --yes` for a non-interactive install. No existing platform behavior changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ From 0.7.0 onwards, Ctxo ships as a pnpm monorepo with five packages. Per-packag
 - `ctxo init` warns when hooks are declined and points to watch/CI alternatives, so users know
   drift/boundary signals depend on snapshot cadence.
 - `ctxo index --skip-community` flag to opt out of community computation.
+- `ctxo init` now supports **Gemini CLI** and **Continue** as installable AI tool targets.
+  - Gemini CLI: writes `GEMINI.md` rules (append mode) and registers the ctxo MCP server at
+    `.gemini/settings.json` (`mcpServers` key).
+  - Continue: writes `.continue/rules/ctxo.md` rules and registers the ctxo MCP server at
+    `.continue/mcpServers/ctxo.json` (each MCP server is a standalone file under
+    `.continue/mcpServers/`).
+  - Brings the supported AI tool list to nine: Claude Code, Cursor, GitHub Copilot, Windsurf,
+    Antigravity, Augment, Amazon Q, Gemini CLI, Continue.
 
 ### Changed
 

--- a/docs/ctxo-hero-html.html
+++ b/docs/ctxo-hero-html.html
@@ -400,7 +400,7 @@
             <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"/>
             <path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
           </svg>
-          <span>Built on <strong>MCP</strong> — works with Claude Code, Copilot, Cursor, Windsurf, Cline &amp; any MCP client</span>
+          <span>Built on <strong>MCP</strong> — works with Claude Code, Copilot, Cursor, Windsurf, Cline, Gemini CLI, Continue &amp; any MCP client</span>
         </div>
       </div>
     </div>

--- a/packages/cli/src/cli/__tests__/ai-rules.test.ts
+++ b/packages/cli/src/cli/__tests__/ai-rules.test.ts
@@ -69,6 +69,21 @@ describe('detectPlatforms', () => {
     expect(detected.has('claude-code')).toBe(true);
     expect(detected.has('github-copilot')).toBe(true);
   });
+
+  it('detects gemini-cli when .gemini/settings.json exists', () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, '.gemini'));
+    writeFileSync(join(dir, '.gemini', 'settings.json'), '{}', 'utf-8');
+    const detected = detectPlatforms(dir);
+    expect(detected.has('gemini-cli')).toBe(true);
+  });
+
+  it('detects continue when .continue/ exists', () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, '.continue'));
+    const detected = detectPlatforms(dir);
+    expect(detected.has('continue')).toBe(true);
+  });
 });
 
 describe('generateRules', () => {
@@ -284,6 +299,20 @@ describe('getMcpConfigTargets', () => {
   it('returns empty for no tools', () => {
     expect(getMcpConfigTargets([])).toHaveLength(0);
   });
+
+  it('returns .gemini/settings.json for gemini-cli', () => {
+    const targets = getMcpConfigTargets(['gemini-cli']);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].file).toBe('.gemini/settings.json');
+    expect(targets[0].serverKey).toBe('mcpServers');
+  });
+
+  it('returns .continue/mcpServers/ctxo.json for continue', () => {
+    const targets = getMcpConfigTargets(['continue']);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].file).toBe('.continue/mcpServers/ctxo.json');
+    expect(targets[0].serverKey).toBe('mcpServers');
+  });
 });
 
 describe('ensureMcpConfig', () => {
@@ -346,5 +375,28 @@ describe('ensureMcpConfig', () => {
     expect(result.action).toBe('updated');
     const config = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
     expect(config.mcpServers.ctxo).toBeDefined();
+  });
+
+  it('creates .gemini/settings.json with mcpServers.ctxo', () => {
+    const dir = makeTempDir();
+    const target = getMcpConfigTargets(['gemini-cli'])[0];
+    const result = ensureMcpConfig(dir, target);
+
+    expect(result.action).toBe('created');
+    const config = JSON.parse(readFileSync(join(dir, '.gemini', 'settings.json'), 'utf-8'));
+    expect(config.mcpServers.ctxo.command).toBe('npx');
+    expect(config.mcpServers.ctxo.args).toContain('@ctxo/cli');
+  });
+
+  it('creates .continue/mcpServers/ctxo.json with mcpServers.ctxo', () => {
+    const dir = makeTempDir();
+    const target = getMcpConfigTargets(['continue'])[0];
+    const result = ensureMcpConfig(dir, target);
+
+    expect(result.action).toBe('created');
+    expect(existsSync(join(dir, '.continue', 'mcpServers', 'ctxo.json'))).toBe(true);
+    const config = JSON.parse(readFileSync(join(dir, '.continue', 'mcpServers', 'ctxo.json'), 'utf-8'));
+    expect(config.mcpServers.ctxo.command).toBe('npx');
+    expect(config.mcpServers.ctxo.args).toContain('@ctxo/cli');
   });
 });

--- a/packages/cli/src/cli/ai-rules.ts
+++ b/packages/cli/src/cli/ai-rules.ts
@@ -28,6 +28,8 @@ export const PLATFORMS: Platform[] = [
   { id: 'antigravity',    name: 'Google Antigravity',  file: 'AGENTS.md',                      mode: 'create',  detectPaths: ['AGENTS.md', 'GEMINI.md', '.gemini'],       starred: false },
   { id: 'augment',        name: 'Augment Code',       file: 'augment-guidelines.md',           mode: 'create',  detectPaths: ['augment-guidelines.md', '.augment'],        starred: false },
   { id: 'amazonq',        name: 'Amazon Q',           file: '.amazonq/rules/ctxo.md',         mode: 'create',  detectPaths: ['.amazonq'],                                starred: false },
+  { id: 'gemini-cli',     name: 'Gemini CLI',          file: 'GEMINI.md',                       mode: 'append',  detectPaths: ['.gemini/settings.json', 'GEMINI.md'],      starred: false },
+  { id: 'continue',       name: 'Continue',            file: '.continue/rules/ctxo.md',         mode: 'create',  detectPaths: ['.continue'],                                starred: false },
 ];
 
 export function detectPlatforms(projectRoot: string): Set<string> {
@@ -255,6 +257,14 @@ export function getMcpConfigTargets(selectedPlatformIds: string[]): McpConfigTar
         break;
       case 'amazonq':
         targets.set('.amazonq/mcp.json', { file: '.amazonq/mcp.json', serverKey: 'mcpServers' });
+        break;
+      case 'gemini-cli':
+        // Gemini CLI reads MCP servers from .gemini/settings.json (project) or ~/.gemini/settings.json (user).
+        targets.set('.gemini/settings.json', { file: '.gemini/settings.json', serverKey: 'mcpServers' });
+        break;
+      case 'continue':
+        // Continue reads each MCP server from a standalone file under .continue/mcpServers/.
+        targets.set('.continue/mcpServers/ctxo.json', { file: '.continue/mcpServers/ctxo.json', serverKey: 'mcpServers' });
         break;
     }
   }

--- a/pages/index.html
+++ b/pages/index.html
@@ -539,7 +539,7 @@
             <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"/>
             <path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
           </svg>
-          <span>Built on <strong>MCP</strong> — works with Claude Code, Copilot, Cursor, Windsurf, Cline &amp; any MCP client</span>
+          <span>Built on <strong>MCP</strong> — works with Claude Code, Copilot, Cursor, Windsurf, Cline, Gemini CLI, Continue &amp; any MCP client</span>
         </div>
       </div>
     </div>

--- a/pages/llms.txt
+++ b/pages/llms.txt
@@ -10,7 +10,7 @@ Ctxo is a Model Context Protocol (MCP) server that delivers Logic-Slices to AI c
 - [Why Ctxo?](https://alperhankendi.github.io/Ctxo/docs/introduction/why-ctxo): Shift the fix-loop left. Proactive, not reactive.
 - [Installation](https://alperhankendi.github.io/Ctxo/docs/introduction/installation): `npx @ctxo/cli init`, then `npx ctxo doctor`.
 - [Quick Start](https://alperhankendi.github.io/Ctxo/docs/introduction/quick-start): Index a repo and make the first MCP call.
-- [MCP Client Setup](https://alperhankendi.github.io/Ctxo/docs/introduction/mcp-client-setup): Claude Code, Cursor, Copilot, Windsurf, Cline.
+- [MCP Client Setup](https://alperhankendi.github.io/Ctxo/docs/introduction/mcp-client-setup): Claude Code, Cursor, Copilot, Windsurf, Cline, Gemini CLI, Continue.
 
 ## Core Concepts
 
@@ -63,6 +63,8 @@ Ctxo is a Model Context Protocol (MCP) server that delivers Logic-Slices to AI c
 - [GitHub Copilot](https://alperhankendi.github.io/Ctxo/docs/integrations/copilot): Copilot Chat.
 - [Windsurf](https://alperhankendi.github.io/Ctxo/docs/integrations/windsurf): Codeium Windsurf.
 - [Cline](https://alperhankendi.github.io/Ctxo/docs/integrations/cline): VS Code extension.
+- [Gemini CLI](https://alperhankendi.github.io/Ctxo/docs/integrations/gemini-cli): Google's Gemini CLI with project-level `GEMINI.md` rules.
+- [Continue](https://alperhankendi.github.io/Ctxo/docs/integrations/continue): VS Code/JetBrains extension; per-server file under `.continue/mcpServers/`.
 - [Raw MCP Client](https://alperhankendi.github.io/Ctxo/docs/integrations/raw-mcp-client): Talk to Ctxo via SDK.
 
 ## Languages

--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -176,6 +176,8 @@ export default defineConfig({
             { text: 'GitHub Copilot', link: '/integrations/copilot' },
             { text: 'Windsurf', link: '/integrations/windsurf' },
             { text: 'Cline', link: '/integrations/cline' },
+            { text: 'Gemini CLI', link: '/integrations/gemini-cli' },
+            { text: 'Continue', link: '/integrations/continue' },
             { text: 'Raw MCP Client', link: '/integrations/raw-mcp-client' },
           ],
         },

--- a/site/docs/cli/init.md
+++ b/site/docs/cli/init.md
@@ -8,8 +8,10 @@ description: "Bootstrap a project: git hooks + plugin install prompt."
 Bootstraps a project for ctxo. Runs three steps:
 
 1. Ensures `.ctxo/index/` and `.ctxo/config.yaml` exist.
-2. Generates MCP usage rules for the AI tools you use (Claude Code, Cursor,
-   Windsurf, etc.) and registers the ctxo MCP server in their config files.
+2. Generates MCP usage rules for the AI tools you use and registers the ctxo
+   MCP server in their config files. Supported tool ids: `claude-code`,
+   `cursor`, `github-copilot`, `windsurf`, `antigravity`, `augment`, `amazonq`,
+   `gemini-cli`, `continue`.
 3. Offers to install missing language plugins and to install git hooks that
    re-index on commit and rebuild the SQLite cache on merge.
 
@@ -38,8 +40,8 @@ npx @ctxo/cli init [options]
 | `.ctxo/index/` | Created if missing (holds per-file JSON indices) |
 | `.ctxo/config.yaml` | Default config is dropped if absent. See [config reference](./config-yaml.md) |
 | `.gitignore` | `.ctxo/.cache/` appended if not already present |
-| AI rule files | For example `.claude/claude.md`, `.cursor/rules/*.mdc`, depending on what you select |
-| AI MCP configs | For example `.mcp.json`, registering `npx -y @ctxo/cli` as a server |
+| AI rule files | Per selected tool: `CLAUDE.md`, `.cursor/rules/ctxo.mdc`, `.github/copilot-instructions.md`, `.windsurfrules`, `AGENTS.md`, `augment-guidelines.md`, `.amazonq/rules/ctxo.md`, `GEMINI.md`, `.continue/rules/ctxo.md` |
+| AI MCP configs | Per selected tool: `.mcp.json` (Claude Code / Cursor / Windsurf / Antigravity / Augment), `.vscode/mcp.json` (Copilot), `.amazonq/mcp.json`, `.gemini/settings.json`, `.continue/mcpServers/ctxo.json` |
 | `.git/hooks/post-commit` | Incremental re-index of changed files (idempotent block, marked `# ctxo-start` / `# ctxo-end`) |
 | `.git/hooks/post-merge` | Runs `ctxo sync` after `git pull` |
 

--- a/site/docs/integrations/continue.md
+++ b/site/docs/integrations/continue.md
@@ -1,0 +1,94 @@
+---
+title: "Continue"
+description: "Continue MCP setup with per-server files under .continue/mcpServers/."
+---
+
+# Continue
+
+[Continue](https://www.continue.dev) is an open-source AI coding assistant
+shipped as VS Code and JetBrains extensions. It stores each MCP server in its
+own file under `.continue/mcpServers/` rather than merging them into one big
+config - a small but important detail when you mix multiple servers.
+
+See [MCP Client Setup](/introduction/mcp-client-setup#continue) for the
+cross-client overview.
+
+## Config file
+
+Continue picks up every JSON or YAML file dropped into:
+
+```
+.continue/mcpServers/
+```
+
+`ctxo init` writes a single file: `.continue/mcpServers/ctxo.json`. To add
+another MCP server later, drop another file next to it - do not edit
+`ctxo.json` to fit two servers in.
+
+The matching rules file is `.continue/rules/ctxo.md` (the Continue v1 rules
+system reads every `.md` under `.continue/rules/`).
+
+## Configuration
+
+`.continue/mcpServers/ctxo.json`:
+
+```json
+{
+  "mcpServers": {
+    "ctxo": {
+      "command": "npx",
+      "args": ["@ctxo/cli", "mcp"]
+    }
+  }
+}
+```
+
+This is the same `mcpServers` schema Cursor / Claude Code use. Continue's docs
+state explicitly that you can copy JSON config files from those tools straight
+into `.continue/mcpServers/` and they work as-is.
+
+## Verify
+
+1. Reload the Continue extension (VS Code: `Continue: Reload` from the command
+   palette).
+2. Open the **MCP** view in the Continue sidebar.
+3. `ctxo` should appear as a green-status server with 14 tools listed
+   underneath, plus the `ctxo://status` resource.
+
+Smoke test, asked in the Continue chat:
+
+> Read the `ctxo://status` resource and tell me when the index was last built.
+
+## Using Ctxo tools
+
+Continue exposes MCP tools to the agent on every turn. Combined with the
+ctxo-rules in `.continue/rules/ctxo.md`, the model gets pushed toward:
+
+- Calling `get_pr_impact` when you ask for a PR review.
+- Calling `get_context_for_task` with the right `taskType` for bugfixes,
+  features, refactors, or understanding.
+- Preferring `search_symbols` / `get_ranked_context` over native file grep.
+
+You can also @-mention tools directly in chat (`@ctxo get_blast_radius
+symbol=...`) when you want to force a specific call.
+
+## Tips
+
+- **One file per server.** If you already had an `.continue/mcpServers/`
+  directory before running `ctxo init`, your other server files stay
+  untouched. Continue auto-discovers all of them.
+- **YAML works too.** Continue accepts `.continue/mcpServers/ctxo.yaml` with
+  the same shape. Stick with JSON unless you have a strong preference - it
+  matches what every other client uses.
+- **Rules vs MCP config are separate concerns.** The MCP file tells Continue
+  *which tools exist*; the rules file in `.continue/rules/ctxo.md` tells it
+  *when to use them*. You need both for the agent to call Ctxo proactively.
+- **Disabled state.** To temporarily turn Ctxo off, rename
+  `ctxo.json` to `ctxo.json.disabled` (or move it out of the directory). No
+  schema flag - Continue discovers by filename.
+
+## Next steps
+
+- [MCP Client Setup](/introduction/mcp-client-setup)
+- [MCP Tools Overview](/mcp-tools/overview)
+- [Quick Start](/introduction/quick-start)

--- a/site/docs/integrations/gemini-cli.md
+++ b/site/docs/integrations/gemini-cli.md
@@ -1,0 +1,92 @@
+---
+title: "Gemini CLI"
+description: "Gemini CLI MCP setup with project-level rules in GEMINI.md."
+---
+
+# Gemini CLI
+
+[Gemini CLI](https://github.com/google-gemini/gemini-cli) is Google's official
+terminal client for the Gemini family. It speaks MCP natively over stdio, and
+reads project instructions from a `GEMINI.md` at the repo root - the same
+"agents-as-markdown" pattern as `CLAUDE.md` / `AGENTS.md`.
+
+See [MCP Client Setup](/introduction/mcp-client-setup#gemini-cli) for the
+cross-client overview.
+
+## Config file
+
+Gemini CLI looks for `mcpServers` in two settings files, project first:
+
+| Scope    | Path                                                |
+| -------- | --------------------------------------------------- |
+| Project  | `.gemini/settings.json` (committed if you want)     |
+| User     | `~/.gemini/settings.json` (global to all projects)  |
+
+`ctxo init` writes the project-level file so the whole team picks up the same
+server config.
+
+## Configuration
+
+Drop this into `.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "ctxo": {
+      "command": "npx",
+      "args": ["@ctxo/cli", "mcp"]
+    }
+  }
+}
+```
+
+Same schema as Claude Code and Cursor. Add `"env": { "DEBUG": "ctxo:*" }` if
+you need stderr logging.
+
+The matching rules file is `GEMINI.md`. `ctxo init` appends a marked block
+between `<!-- ctxo-rules-start -->` / `<!-- ctxo-rules-end -->` so subsequent
+re-runs replace just that block without touching the rest of your file.
+
+## Verify
+
+```bash
+gemini --help        # confirm the binary is on PATH
+cd path/to/repo
+gemini               # start an interactive session
+```
+
+Inside the session ask Gemini to list its MCP tools - the 14 Ctxo tools
+(`get_logic_slice`, `get_blast_radius`, ...) should appear with one resource
+`ctxo://status`.
+
+Smoke test:
+
+> Use Ctxo's `ctxo://status` resource and tell me when the index was last built.
+
+## Using Ctxo tools
+
+Because Gemini CLI honours `GEMINI.md` as a system prompt, the rules `ctxo init`
+installs there are enforced on every turn. The agent is told:
+
+- Call `get_blast_radius` before editing a function.
+- Call `get_why_context` before trusting recently-changed code.
+- Use `search_symbols` / `get_ranked_context` instead of grepping for names.
+
+This means you do not have to remind Gemini per-message - the rules ride along
+with the session.
+
+## Tips
+
+- **Project file beats user file.** If both `.gemini/settings.json` and
+  `~/.gemini/settings.json` define `mcpServers.ctxo`, the project copy wins.
+  Useful when one repo needs a pinned binary path and another can use `npx`.
+- **`GEMINI.md` is large-context-friendly.** Keep team conventions there
+  alongside the ctxo-rules block - Gemini's 1M-token window handles it.
+- **No `disabled` flag.** To turn Ctxo off, remove (or rename) the
+  `mcpServers.ctxo` entry. Restart the CLI to pick the change up.
+
+## Next steps
+
+- [MCP Client Setup](/introduction/mcp-client-setup)
+- [MCP Tools Overview](/mcp-tools/overview)
+- [Quick Start](/introduction/quick-start)

--- a/site/docs/introduction/mcp-client-setup.md
+++ b/site/docs/introduction/mcp-client-setup.md
@@ -1,6 +1,6 @@
 ---
 title: "MCP Client Setup"
-description: "Per-client config for Claude Code, Cursor, Copilot, Windsurf, and Cline. Copy-paste JSON blocks for stdio MCP."
+description: "Per-client config for Claude Code, Cursor, Copilot, Windsurf, Cline, Gemini CLI, and Continue. Copy-paste JSON blocks for stdio MCP."
 ---
 
 # MCP Client Setup
@@ -133,6 +133,51 @@ directly:
 ```
 
 See [Cline integration](/integrations/cline) for more.
+
+## Gemini CLI
+
+Gemini CLI reads MCP servers from `.gemini/settings.json` (per-project) or
+`~/.gemini/settings.json` (global). Use the same `mcpServers` schema as Claude
+Code and Cursor:
+
+```json
+{
+  "mcpServers": {
+    "ctxo": {
+      "command": "npx",
+      "args": ["@ctxo/cli", "mcp"]
+    }
+  }
+}
+```
+
+Project-level rules live in `GEMINI.md` at the repo root - `ctxo init` appends
+a marked section there. Restart `gemini` after editing.
+
+## Continue
+
+Continue keeps each MCP server in its own JSON (or YAML) file under
+`.continue/mcpServers/`. Create `.continue/mcpServers/ctxo.json`:
+
+```json
+{
+  "mcpServers": {
+    "ctxo": {
+      "command": "npx",
+      "args": ["@ctxo/cli", "mcp"]
+    }
+  }
+}
+```
+
+::: tip One file per server
+Unlike Cursor / Claude Code where one config holds every server, Continue picks
+up each `.continue/mcpServers/*.json` file separately. To add another MCP
+server, drop another file next to `ctxo.json` rather than appending to it.
+:::
+
+Project rules go to `.continue/rules/ctxo.md`. Reload Continue from the VS Code
+command palette after the install.
 
 ## Using a pinned binary instead of npx
 

--- a/site/docs/introduction/what-is-ctxo.md
+++ b/site/docs/introduction/what-is-ctxo.md
@@ -14,7 +14,7 @@ change-health scores, all in a single sub-500ms call.
 ## What Ctxo is
 
 - An **MCP server** over stdio, compatible with Claude Code, Cursor, Copilot,
-  Windsurf, Cline, and any raw MCP client.
+  Windsurf, Cline, Gemini CLI, Continue, and any raw MCP client.
 - A **CLI** (`@ctxo/cli`) that builds and maintains a committed, deterministic
   index of your code at `.ctxo/`.
 - **14 semantic tools** spanning impact analysis (`get_blast_radius`,

--- a/site/docs/public/llms.txt
+++ b/site/docs/public/llms.txt
@@ -10,7 +10,7 @@ Ctxo is a Model Context Protocol (MCP) server that delivers Logic-Slices to AI c
 - [Why Ctxo?](https://alperhankendi.github.io/Ctxo/docs/introduction/why-ctxo): Shift the fix-loop left. Proactive, not reactive.
 - [Installation](https://alperhankendi.github.io/Ctxo/docs/introduction/installation): `npx @ctxo/cli init`, then `npx ctxo doctor`.
 - [Quick Start](https://alperhankendi.github.io/Ctxo/docs/introduction/quick-start): Index a repo and make the first MCP call.
-- [MCP Client Setup](https://alperhankendi.github.io/Ctxo/docs/introduction/mcp-client-setup): Claude Code, Cursor, Copilot, Windsurf, Cline.
+- [MCP Client Setup](https://alperhankendi.github.io/Ctxo/docs/introduction/mcp-client-setup): Claude Code, Cursor, Copilot, Windsurf, Cline, Gemini CLI, Continue.
 
 ## Core Concepts
 
@@ -63,6 +63,8 @@ Ctxo is a Model Context Protocol (MCP) server that delivers Logic-Slices to AI c
 - [GitHub Copilot](https://alperhankendi.github.io/Ctxo/docs/integrations/copilot): Copilot Chat.
 - [Windsurf](https://alperhankendi.github.io/Ctxo/docs/integrations/windsurf): Codeium Windsurf.
 - [Cline](https://alperhankendi.github.io/Ctxo/docs/integrations/cline): VS Code extension.
+- [Gemini CLI](https://alperhankendi.github.io/Ctxo/docs/integrations/gemini-cli): Google's Gemini CLI with project-level `GEMINI.md` rules.
+- [Continue](https://alperhankendi.github.io/Ctxo/docs/integrations/continue): VS Code/JetBrains extension; per-server file under `.continue/mcpServers/`.
 - [Raw MCP Client](https://alperhankendi.github.io/Ctxo/docs/integrations/raw-mcp-client): Talk to Ctxo via SDK.
 
 ## Languages


### PR DESCRIPTION
## Summary

- Extends `ctxo init` from 7 to 9 supported AI tools: adds **Gemini CLI** and **Continue**.
- Gemini CLI: appends a marked ctxo-rules block to `GEMINI.md` and registers the ctxo MCP server at `.gemini/settings.json` (`mcpServers` key, identical schema to Claude Code / Cursor).
- Continue: writes `.continue/rules/ctxo.md` and registers the server as a standalone file at `.continue/mcpServers/ctxo.json` (Continue picks up each file in that directory separately).
- Adds 6 new tests; existing platform behavior unchanged.
- Docs updated end-to-end: CHANGELOG, VitePress sidebar + integration pages, MCP client setup, landing-page MCP strip, llms.txt mirrors.
- Changeset: `@ctxo/cli` patch.

## Test plan

- [x] `pnpm --filter @ctxo/cli typecheck` clean
- [x] `pnpm --filter @ctxo/cli test` (ai-rules.test.ts: 45/45; full suite: 1089/1089 actual tests pass; one Windows-only `afterAll` tempdir cleanup `EPERM` on `tests/e2e/privacy-zero-leakage.test.ts` is a pre-existing flake unrelated to this change, all 5 tests inside pass)
- [x] `cd site && pnpm vitepress build docs` — 0 broken links, new sidebar links resolve to the new integration pages
- [ ] CI: typecheck + test + build green
- [ ] Manual smoke: `npx @ctxo/cli init --tools gemini-cli,continue --yes --dry-run` lists the new tool ids