### PR TITLE
docs: use scoped npx @ctxo/cli everywhere; add global install path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,32 +23,32 @@ pnpm --filter @ctxo/cli test:e2e  # end-to-end tests
 pnpm --filter @ctxo/cli build     # build CLI package to dist/
 
 # Usage (consumer)
-npx ctxo install                     # install language plugins (interactive)
-npx ctxo install typescript go --yes # non-interactive install of specific plugins
-npx ctxo install --dry-run --pm pnpm # preview install plan with chosen pm
-npx ctxo update                      # check + apply updates for ctxo + plugins
-npx ctxo update --check              # check only, exit 0
-npx ctxo update --print              # print install command, never execute
-npx ctxo update --global             # force a global install
-npx ctxo update --json               # machine-readable output
-npx ctxo index                       # build codebase index
-npx ctxo index --install-missing     # auto-install detected plugins, then index
-npx ctxo index --check               # CI gate: fail if index stale
-npx ctxo index --skip-history        # fast re-index without git history
-npx ctxo index --max-history 5       # limit commit history per file
-npx ctxo watch                       # file watcher for incremental re-index
-npx ctxo sync                        # rebuild SQLite from committed JSON
-npx ctxo init                        # install git hooks + language detection/install prompt
-npx ctxo init --no-install           # init without plugin install prompt
-npx ctxo status                      # show index manifest
-npx ctxo doctor                      # health check all subsystems (--json, --quiet)
-npx ctxo doctor --fix                # dependency-ordered remediation (--dry-run, --yes)
-npx ctxo version                     # verbose version report (default)
-npx ctxo --version --verbose         # version + installed plugins list
-npx ctxo --version --json            # machine-readable version report
-npx ctxo visualize                   # generate interactive dependency graph HTML
-npx ctxo visualize --max-nodes 200   # limit to top 200 symbols by PageRank
-npx ctxo visualize --no-browser      # skip auto-opening browser
+npx @ctxo/cli install                     # install language plugins (interactive)
+npx @ctxo/cli install typescript go --yes # non-interactive install of specific plugins
+npx @ctxo/cli install --dry-run --pm pnpm # preview install plan with chosen pm
+npx @ctxo/cli update                      # check + apply updates for ctxo + plugins
+npx @ctxo/cli update --check              # check only, exit 0
+npx @ctxo/cli update --print              # print install command, never execute
+npx @ctxo/cli update --global             # force a global install
+npx @ctxo/cli update --json               # machine-readable output
+npx @ctxo/cli index                       # build codebase index
+npx @ctxo/cli index --install-missing     # auto-install detected plugins, then index
+npx @ctxo/cli index --check               # CI gate: fail if index stale
+npx @ctxo/cli index --skip-history        # fast re-index without git history
+npx @ctxo/cli index --max-history 5       # limit commit history per file
+npx @ctxo/cli watch                       # file watcher for incremental re-index
+npx @ctxo/cli sync                        # rebuild SQLite from committed JSON
+npx @ctxo/cli init                        # install git hooks + language detection/install prompt
+npx @ctxo/cli init --no-install           # init without plugin install prompt
+npx @ctxo/cli status                      # show index manifest
+npx @ctxo/cli doctor                      # health check all subsystems (--json, --quiet)
+npx @ctxo/cli doctor --fix                # dependency-ordered remediation (--dry-run, --yes)
+npx @ctxo/cli version                     # verbose version report (default)
+npx @ctxo/cli --version --verbose         # version + installed plugins list
+npx @ctxo/cli --version --json            # machine-readable version report
+npx @ctxo/cli visualize                   # generate interactive dependency graph HTML
+npx @ctxo/cli visualize --max-nodes 200   # limit to top 200 symbols by PageRank
+npx @ctxo/cli visualize --no-browser      # skip auto-opening browser
 
 # Environment
 DEBUG=ctxo:*                  # enable all debug output

--- a/docs/artifacts/architecture.md
+++ b/docs/artifacts/architecture.md
@@ -162,7 +162,7 @@ TypeScript 5.x, ESM-first (`"type": "module"`), Node.js ≥ 20, `tsconfig.json` 
 **Build Tooling:**
 tsup (esbuild-backed) with `external: ['better-sqlite3', 'tree-sitter']` to preserve
 native addon `.node` binary resolution. Single `dist/index.js` output, `bin` field
-in `package.json` for `npx ctxo` invocation.
+in `package.json` for `npx @ctxo/cli` invocation.
 
 **Testing Framework:**
 Vitest (ESM-native, fast, Jest-compatible API). Unit tests per adapter, integration
@@ -251,13 +251,13 @@ The committed JSON index enables CI-driven index freshness:
 
 **Pattern A — CI writes index (recommended):**
 ```yaml
-- run: npx ctxo index
+- run: npx @ctxo/cli index
 - run: git add .ctxo/index/ && git diff --staged --quiet || git commit -m "chore: update ctxo index [skip ci]" && git push
 ```
 
 **Pattern B — CI gate (simpler):**
 ```yaml
-- run: npx ctxo index
+- run: npx @ctxo/cli index
 - run: git diff --exit-code .ctxo/index/   # fail PR if index not committed
 ```
 
@@ -320,7 +320,7 @@ Warn-and-continue at every boundary:
 
 ### Infrastructure & Deployment
 
-- **Package**: single npm package `ctxo`, `bin` field for `npx ctxo` invocation
+- **Package**: single npm package `ctxo`, `bin` field for `npx @ctxo/cli` invocation
 - **Build**: tsup with `external: ['better-sqlite3', 'tree-sitter']`
 - **Engines**: Node.js ≥ 20
 - **MCP client config**: `{ "command": "npx", "args": ["-y", "ctxo"] }`
@@ -637,7 +637,7 @@ Clients spawn Ctxo as a stdio subprocess. Zero configuration beyond this line.
 
 **CI integration:**
 ```yaml
-- run: npx ctxo index
+- run: npx @ctxo/cli index
 - run: git diff --exit-code .ctxo/index/
 ```
 

--- a/docs/artifacts/epics.md
+++ b/docs/artifacts/epics.md
@@ -95,7 +95,7 @@ NFR10: Ctxo runs with no elevated privileges; does not require sudo or admin rig
 NFR11: Index staleness is detected and reported within the MCP tool response — never silently served as fresh context
 NFR12: A crashed or stopped file watcher does not corrupt the committed index; on restart re-validates state before resuming
 NFR13: If the SQLite cache is deleted or corrupted, Ctxo rebuilds it from the committed JSON index without user intervention
-NFR14: `npx ctxo index --check` exits with a non-zero code when any source file has been modified after the index was last built
+NFR14: `npx @ctxo/cli index --check` exits with a non-zero code when any source file has been modified after the index was last built
 NFR15: Ctxo implements the MCP specification without extensions or deviations that break conformant MCP client compatibility
 NFR16: All five MCP tools are tested for functional equivalence across Claude Code, Cursor, and VS Code Copilot before V1 release
 NFR17: The MCP server exposes a `tools/list` response conformant with the MCP spec
@@ -108,7 +108,7 @@ Architecture & Infrastructure:
 - AR2: No starter template — custom tsup + TypeScript setup from scratch; first story is project scaffold
 - AR3: ESM-first ("type": "module"), ES2022 target, Node16 module resolution in tsconfig
 - AR4: tsup build with external: ['better-sqlite3', 'tree-sitter'] to preserve native addon .node binary resolution
-- AR5: Single dist/index.js output with bin field in package.json for npx ctxo invocation
+- AR5: Single dist/index.js output with bin field in package.json for npx @ctxo/cli invocation
 
 Hexagonal Architecture Rules (enforced by ESLint import/no-restricted-paths):
 - AR6: core/ NEVER imports from adapters/ — pure domain logic only
@@ -133,7 +133,7 @@ Index & Storage:
 
 CI/CD Patterns:
 - AR21: CLI commands required: ctxo index, ctxo sync, ctxo verify-index
-- AR22: CI gate pattern: npx ctxo index then git diff --exit-code .ctxo/index/
+- AR22: CI gate pattern: npx @ctxo/cli index then git diff --exit-code .ctxo/index/
 - AR23: Optional git hooks installed via ctxo init: post-commit (ctxo index --since HEAD~1), post-merge (ctxo sync)
 
 Testing Requirements:
@@ -194,7 +194,7 @@ Developer installs Ctxo with a single command, indexes their TypeScript codebase
 - ESLint configured with `import/no-restricted-paths`: `core/` cannot import from `adapters/`; `ports/` cannot import from `adapters/`
 - ESLint rule bans `console.log` anywhere in `src/` (use `console.error` only)
 - `vitest` configured with coverage threshold ≥ 90% for `src/core/`
-- `npx ctxo --help` exits 0 after `tsup` build
+- `npx @ctxo/cli --help` exits 0 after `tsup` build
 
 #### Story 1.2: Storage Foundation — IStoragePort, JSON Index Writer & SQLite Cache
 **As a** developer, **I want** a storage layer that writes per-file JSON index artifacts and maintains a local SQLite query cache, **so that** the index is git-committable and the cache is fast and recoverable.
@@ -282,7 +282,7 @@ Developer installs Ctxo with a single command, indexes their TypeScript codebase
 - Completes in ≤ 30s for 1,000-file codebase on M-series Mac (measured in E2E test)
 - `.ctxo/index/schema-version` written/updated
 - `.ctxo/.cache/` added to `.gitignore` if not present
-- `npx ctxo index` exits 0 on success, non-zero on unrecoverable error
+- `npx @ctxo/cli index` exits 0 on success, non-zero on unrecoverable error
 - E2E test: fixture TypeScript project → run `ctxo index` → assert `.ctxo/index/` files created
 
 ### Epic 2: Risk Intelligence — Blast Radius & Architectural Overlay
@@ -449,7 +449,7 @@ Team commits the index to git as text-based per-file JSON, CI gates stale PRs, n
 - `ctxo verify-index` runs `ctxo index` (re-indexes everything) then checks `git diff --exit-code .ctxo/index/`
 - Exits 0 if no diff (index is current)
 - Exits 1 if diff present; prints list of changed index files to stderr
-- Suitable for use in GitHub Actions `- run: npx ctxo verify-index` step
+- Suitable for use in GitHub Actions `- run: npx @ctxo/cli verify-index` step
 - E2E test: source modified without re-indexing → `ctxo verify-index` exits 1
 
 #### Story 5.4: Monorepo Auto-Discovery
@@ -517,14 +517,14 @@ All five MCP tools verified functional across Claude Code, Cursor, and VS Code C
 - Any match → test fails with specific pattern + location reported
 - Gate runs in CI on every PR and blocks merge on failure
 
-#### Story 6.5: `npx ctxo` Release Packaging
-**As a** developer, **I want** `npx ctxo` to just work with zero prior installation, **so that** adoption friction is minimal.
+#### Story 6.5: `npx @ctxo/cli` Release Packaging
+**As a** developer, **I want** `npx @ctxo/cli` to just work with zero prior installation, **so that** adoption friction is minimal.
 
 **Acceptance Criteria:**
 - `package.json` `bin` field maps `ctxo` → `dist/index.js`
 - `files` field includes only `dist/`, `README.md`, `LICENSE`
-- `npx ctxo --help` works without prior `npm install`
-- `npx ctxo index` on a fresh TypeScript project produces `.ctxo/index/` successfully
+- `npx @ctxo/cli --help` works without prior `npm install`
+- `npx @ctxo/cli index` on a fresh TypeScript project produces `.ctxo/index/` successfully
 - `npm pack` → inspect tarball → no source code, no test fixtures, no `.ctxo/` artifacts included
 - Pre-publish checklist documented in `RELEASING.md`
 

--- a/docs/artifacts/prd.md
+++ b/docs/artifacts/prd.md
@@ -60,7 +60,7 @@ The paradigm shift: from *you managing the AI* → *the AI guiding you*, because
 ### User Success
 
 - **Mind-Reader Moment:** In a Ctxo-enabled session, the AI never asks "I don't see the definition for Type X" — all required interfaces, types, and helpers are present in the Logic-Slice without manual file-fetching.
-- **Time to first value:** Developer installs Ctxo, runs `npx ctxo index`, and receives their first Logic-Slice response within 5 minutes of a fresh clone.
+- **Time to first value:** Developer installs Ctxo, runs `npx @ctxo/cli index`, and receives their first Logic-Slice response within 5 minutes of a fresh clone.
 - **Zero-Noise output:** Logic-Slice context is ≤ 50–150 lines for the majority of symbol queries (vs. full file dumps spanning hundreds of lines), reducing token cost while increasing relevance.
 - **PR-Saver moment:** For codebases with revert commits in git history, `get_why_context` surfaces anti-pattern warnings in at least one AI session per team per sprint.
 
@@ -86,11 +86,11 @@ The paradigm shift: from *you managing the AI* → *the AI guiding you*, because
 
 ### V1 — MVP (TypeScript / JavaScript / TSX)
 
-Five MCP tools: `get_logic_slice`, `get_blast_radius`, `get_architectural_overlay`, `get_why_context`, `get_change_intelligence`. Progressive detail levels L1–L4. Privacy masking pipeline. Committed JSON index (`.ctxo/index/`). Incremental file watching. Monorepo auto-discovery. CI indexing gate (GitHub Actions). `npx ctxo` install. Verified: Claude Code, Cursor, VS Code Copilot.
+Five MCP tools: `get_logic_slice`, `get_blast_radius`, `get_architectural_overlay`, `get_why_context`, `get_change_intelligence`. Progressive detail levels L1–L4. Privacy masking pipeline. Committed JSON index (`.ctxo/index/`). Incremental file watching. Monorepo auto-discovery. CI indexing gate (GitHub Actions). `npx @ctxo/cli` install. Verified: Claude Code, Cursor, VS Code Copilot.
 
 ### V1.5 — Growth (Multi-language)
 
-Go + C# syntax-level support via tree-sitter adapters. `npx ctxo init` auto-configures MCP client. Dedicated documentation site. `npx ctxo status` index health CLI.
+Go + C# syntax-level support via tree-sitter adapters. `npx @ctxo/cli init` auto-configures MCP client. Dedicated documentation site. `npx @ctxo/cli status` index health CLI.
 
 ### V2+ — Vision
 
@@ -105,7 +105,7 @@ Multi-repo / cross-service dependency graphs. Natural language query interface. 
 She finds Ctxo in the Claude Code MCP server list. Thirty seconds:
 
 ```bash
-npx ctxo index
+npx @ctxo/cli index
 ```
 
 Index builds in 18 seconds. She adds the one-line MCP config and reloads Claude Code.
@@ -126,7 +126,7 @@ He reviews the `.ctxo/index/` output — one JSON file per source file, 3.2MB to
 
 The PR description writes itself: *"Adds Ctxo index — gives AI assistants full dependency context on this codebase. Pull and you're context-rich immediately."*
 
-He adds the GitHub Actions CI gate. Now every PR triggers `npx ctxo index --check` — CI fails if the index is stale. Institutional memory stays current automatically.
+He adds the GitHub Actions CI gate. Now every PR triggers `npx @ctxo/cli index --check` — CI fails if the index is stale. Institutional memory stays current automatically.
 
 Three weeks later, a new hire clones the repo. Full context on day one. Daniel never has to explain the `PaymentProcessor` dependency graph again.
 
@@ -156,9 +156,9 @@ Priya didn't know that history existed. Nobody told her. The codebase told her.
 
 He queries `InvoiceGenerator`. The response is missing `TaxCalculator` — a dependency he knows exists. He checks: feature branch, three days old, `TaxCalculator` added yesterday, index never updated.
 
-Ctxo surfaces a warning in the MCP response: *"Index for invoice-generator.ts is 3 days old and may not reflect recent changes. Run `npx ctxo index --file src/billing/invoice-generator.ts` to update."*
+Ctxo surfaces a warning in the MCP response: *"Index for invoice-generator.ts is 3 days old and may not reflect recent changes. Run `npx @ctxo/cli index --file src/billing/invoice-generator.ts` to update."*
 
-Two seconds. The next query includes `TaxCalculator`. He adds `npx ctxo watch` to his dev startup script.
+Two seconds. The next query includes `TaxCalculator`. He adds `npx @ctxo/cli watch` to his dev startup script.
 
 **Capabilities revealed:** Index staleness detection, incremental file-level re-indexing, `ctxo watch` file watcher, graceful degradation with actionable warnings.
 
@@ -223,10 +223,10 @@ Ctxo is an npm package distributed via `npx`, exposing an MCP server over stdio 
 
 ### Installation Methods
 
-- **Primary:** `npx ctxo index` — zero global install, always-latest
+- **Primary:** `npx @ctxo/cli index` — zero global install, always-latest
 - **Global install:** `npm install -g ctxo` — for teams preferring pinned versions
 - **MCP client config:** `{ "command": "npx", "args": ["-y", "ctxo"] }`
-- **CI:** `npx ctxo index --check` in GitHub Actions workflow
+- **CI:** `npx @ctxo/cli index --check` in GitHub Actions workflow
 
 ### API Surface (MCP Tools)
 
@@ -260,7 +260,7 @@ All tools return structured JSON. Privacy masking applied to all outputs before 
 - All five MCP tools with L1–L4 progressive depth
 - Privacy masking pipeline
 - Committed JSON index + `.gitignore` cache separation
-- `npx ctxo index` + incremental re-indexing + `ctxo watch`
+- `npx @ctxo/cli index` + incremental re-indexing + `ctxo watch`
 - CI indexing gate (GitHub Actions)
 - Monorepo auto-discovery
 - MCP stdio transport, verified: Claude Code, Cursor, VS Code Copilot
@@ -351,7 +351,7 @@ All tools return structured JSON. Privacy masking applied to all outputs before 
 - **NFR11:** Index staleness is detected and reported within the MCP tool response — never silently served as fresh context
 - **NFR12:** A crashed or stopped file watcher does not corrupt the committed index; on restart, the watcher re-validates index state before resuming
 - **NFR13:** If the SQLite cache is deleted or corrupted, Ctxo rebuilds it from the committed JSON index without user intervention
-- **NFR14:** `npx ctxo index --check` exits with a non-zero code when any source file has been modified after the index was last built
+- **NFR14:** `npx @ctxo/cli index --check` exits with a non-zero code when any source file has been modified after the index was last built
 
 ### Integration
 
@@ -377,7 +377,7 @@ All tools return structured JSON. Privacy masking applied to all outputs before 
 
 ### E2E Tests
 
-- **Scope:** Full `npx ctxo` CLI — index build, incremental re-index, `--check` exit codes, file watcher trigger
+- **Scope:** Full `npx @ctxo/cli` CLI — index build, incremental re-index, `--check` exit codes, file watcher trigger
 - **Approach:** Real TypeScript fixture projects on disk; CI runs on Linux (`ubuntu-latest`) against Node.js 20 and 22. Node 18 dropped after upstream EOL (2025-04); macOS/Windows supported at runtime but not continuously CI-verified.
 - **Key cases:** Index build on clean project produces valid manifest; `--check` exits non-zero after source file modification; incremental re-index updates only the changed file's JSON; `ctxo watch` detects a save and re-indexes within 2s
 

--- a/docs/artifacts/product-brief-Ctxo.md
+++ b/docs/artifacts/product-brief-Ctxo.md
@@ -24,7 +24,7 @@ Ctxo runs entirely on the developer's machine. Its index is committed alongside 
 
 Getting started takes 30 seconds:
 ```bash
-npx ctxo index         # builds the index for the first time (~10–30s for 1,000 files)
+npx @ctxo/cli index         # builds the index for the first time (~10–30s for 1,000 files)
 ```
 ```json
 { "command": "npx", "args": ["-y", "ctxo"] }
@@ -97,7 +97,7 @@ Teams onboarding new developers onto complex codebases, or teams that have lost 
 ## Scope
 
 **V1 — TypeScript / JavaScript (full feature set):**
-Logic-Slice, Blast Radius, Architectural Overlay, Why-Context + Anti-Pattern Memory, Change Intelligence, Privacy Masking, Progressive Detail Levels (L1–L4), Monorepo auto-discovery, CI indexing gate, incremental file watching, `npx ctxo` install.
+Logic-Slice, Blast Radius, Architectural Overlay, Why-Context + Anti-Pattern Memory, Change Intelligence, Privacy Masking, Progressive Detail Levels (L1–L4), Monorepo auto-discovery, CI indexing gate, incremental file watching, `npx @ctxo/cli` install.
 
 **V1.5 — Multi-language syntax tier:**
 Go + C# via tree-sitter. Same five tools, AST-level analysis (no type inference). Addresses the backend and enterprise polyglot developer segment.

--- a/docs/runbook/real-world-validation/real-world-validation.md
+++ b/docs/runbook/real-world-validation/real-world-validation.md
@@ -32,15 +32,15 @@ When Phase B lands: add Django PetClinic for Python and Spring PetClinic for Jav
    ```
 3. Build the index, recording wall time:
    ```bash
-   time npx ctxo index
+   time npx @ctxo/cli index
    ```
 4. Run doctor and capture the report:
    ```bash
-   npx ctxo doctor --json > doctor.json
+   npx @ctxo/cli doctor --json > doctor.json
    ```
 5. Smoke the main MCP tools against a hand-picked hot symbol:
    ```bash
-   npx ctxo search symbols "<hot-symbol-name>"
+   npx @ctxo/cli search symbols "<hot-symbol-name>"
    # note symbolId
    # call get_blast_radius, get_logic_slice, get_context_for_task via your MCP client
    ```

--- a/examples/community-plugin-template/README.md
+++ b/examples/community-plugin-template/README.md
@@ -50,8 +50,8 @@ User project
    cd /path/to/test-project
    npm install /path/to/ctxo-lang-yourlang   # local link
    npm install @ctxo/cli@next
-   npx ctxo index
-   npx ctxo doctor --quiet
+   npx @ctxo/cli index
+   npx @ctxo/cli doctor --quiet
    ```
 
    Your plugin should appear in `ctxo doctor`'s Versions section. Indexing should produce symbols in `.ctxo/index/`.

--- a/packages/cli/src/adapters/transport/http-server-transport.ts
+++ b/packages/cli/src/adapters/transport/http-server-transport.ts
@@ -17,8 +17,8 @@ export type ServerFactory = () => Promise<McpServer>;
  * This avoids the "already connected" error when multiple clients connect.
  *
  * Usage:
- *   CTXO_HTTP_PORT=3001 npx ctxo
- *   npx ctxo --http
+ *   CTXO_HTTP_PORT=3001 npx @ctxo/cli
+ *   npx @ctxo/cli --http
  */
 export async function startHttpTransport(
   serverFactory: ServerFactory,

--- a/packages/cli/src/cli/init-command.ts
+++ b/packages/cli/src/cli/init-command.ts
@@ -361,8 +361,8 @@ export class InitCommand {
     const hasWork = (selectedTools as string[]).length > 0 || installGitHooks;
     if (hasWork) {
       const steps = [
-        `${pc.cyan('\u25b6')} npx ctxo index     ${pc.dim('\u2500 build codebase index')}`,
-        `${pc.cyan('\u25b6')} npx ctxo doctor    ${pc.dim('\u2500 verify everything works')}`,
+        `${pc.cyan('\u25b6')} ctxo index     ${pc.dim('\u2500 build codebase index')}`,
+        `${pc.cyan('\u25b6')} ctxo doctor    ${pc.dim('\u2500 verify everything works')}`,
       ];
       console.error('');
       console.error(box(steps, { title: pc.cyan('\u2192 Next steps'), border: pc.cyan }, pc));

--- a/site/docs/cli/doctor.md
+++ b/site/docs/cli/doctor.md
@@ -13,7 +13,7 @@ index last).
 ## Synopsis
 
 ```shell
-npx ctxo doctor [options]
+npx @ctxo/cli doctor [options]
 ```
 
 ## Flags
@@ -68,25 +68,25 @@ This keeps the command safe to expose in shared scripts.
 
 ::: code-group
 ```shell [human report]
-npx ctxo doctor
+npx @ctxo/cli doctor
 ```
 
 ```shell [quiet]
 # Only print non-passing checks — good for shell prompts.
-npx ctxo doctor --quiet
+npx @ctxo/cli doctor --quiet
 ```
 
 ```shell [machine readable]
 # Pipe to jq for dashboards.
-npx ctxo doctor --json | jq '.checks | map(select(.status != "pass"))'
+npx @ctxo/cli doctor --json | jq '.checks | map(select(.status != "pass"))'
 ```
 
 ```shell [dry-run fix]
-npx ctxo doctor --fix --dry-run
+npx @ctxo/cli doctor --fix --dry-run
 ```
 
 ```shell [apply fixes in CI]
-npx ctxo doctor --fix --yes
+npx @ctxo/cli doctor --fix --yes
 ```
 :::
 

--- a/site/docs/cli/env-vars.md
+++ b/site/docs/cli/env-vars.md
@@ -47,7 +47,7 @@ Invalid values (non-numeric, zero, negative) fall back to the default.
 
 ```shell
 # Give large tool responses more room at the cost of token usage.
-CTXO_RESPONSE_LIMIT=16384 npx ctxo
+CTXO_RESPONSE_LIMIT=16384 npx @ctxo/cli
 ```
 
 ## Package manager override
@@ -57,7 +57,7 @@ CTXO_RESPONSE_LIMIT=16384 npx ctxo
 | `CTXO_PM` | `npm`, `pnpm`, `yarn`, `bun` | Forces [`ctxo install`](./install.md) to use the given manager, overriding detection from `packageManager`, lockfile, and auto-detection |
 
 ```shell
-CTXO_PM=pnpm npx ctxo install typescript go
+CTXO_PM=pnpm npx @ctxo/cli install typescript go
 ```
 
 ## HTTP transport (optional)
@@ -70,7 +70,7 @@ integrations that require it.
 | `CTXO_HTTP_PORT` | unset | When set, the MCP server listens on the given HTTP port instead of stdio |
 
 ```shell
-CTXO_HTTP_PORT=3001 npx ctxo
+CTXO_HTTP_PORT=3001 npx @ctxo/cli
 ```
 
 ## CI detection
@@ -83,17 +83,17 @@ CTXO_HTTP_PORT=3001 npx ctxo
 
 ```shell
 # Full visibility while debugging a flaky index run.
-DEBUG=ctxo:* npx ctxo index
+DEBUG=ctxo:* npx @ctxo/cli index
 ```
 
 ```shell
 # Narrow to plugin and storage subsystems.
-DEBUG=ctxo:plugin-loader,ctxo:plugin-discovery,ctxo:storage npx ctxo index
+DEBUG=ctxo:plugin-loader,ctxo:plugin-discovery,ctxo:storage npx @ctxo/cli index
 ```
 
 ```shell
 # Raise response budget for large Logic-Slice queries.
-CTXO_RESPONSE_LIMIT=16384 DEBUG=ctxo:search npx ctxo
+CTXO_RESPONSE_LIMIT=16384 DEBUG=ctxo:search npx @ctxo/cli
 ```
 
 ## See also

--- a/site/docs/cli/index.md
+++ b/site/docs/cli/index.md
@@ -19,7 +19,7 @@ discovered and indexed.
 ## Synopsis
 
 ```shell
-npx ctxo index [options]
+npx @ctxo/cli index [options]
 ```
 
 ## Flags
@@ -36,31 +36,31 @@ npx ctxo index [options]
 
 ::: code-group
 ```shell [full index]
-npx ctxo index
+npx @ctxo/cli index
 ```
 
 ```shell [CI gate]
 # Fail the build if the committed index has drifted from source.
-npx ctxo index --check
+npx @ctxo/cli index --check
 ```
 
 ```shell [fast re-index]
 # Skip git history. Useful on a fresh clone, or in hot-path benchmarks.
-npx ctxo index --skip-history
+npx @ctxo/cli index --skip-history
 ```
 
 ```shell [bounded history]
-npx ctxo index --max-history 5
+npx @ctxo/cli index --max-history 5
 ```
 
 ```shell [bootstrap]
 # Install detected plugins, then index in one command.
-npx ctxo index --install-missing
+npx @ctxo/cli index --install-missing
 ```
 
 ```shell [single file]
 # Invoked by the post-commit hook; runs in milliseconds.
-npx ctxo index --file packages/cli/src/core/logger.ts
+npx @ctxo/cli index --file packages/cli/src/core/logger.ts
 ```
 :::
 

--- a/site/docs/cli/install.md
+++ b/site/docs/cli/install.md
@@ -19,7 +19,7 @@ plugins that are not yet present.
 ## Synopsis
 
 ```shell
-npx ctxo install [languages...] [options]
+npx @ctxo/cli install [languages...] [options]
 ```
 
 ## Flags
@@ -58,27 +58,27 @@ The manager is resolved in this order:
 ::: code-group
 ```shell [auto-detect]
 # Detect languages in the repo and install anything missing.
-npx ctxo install
+npx @ctxo/cli install
 ```
 
 ```shell [explicit]
 # Install TypeScript and Go plugins, no prompts.
-npx ctxo install typescript go --yes
+npx @ctxo/cli install typescript go --yes
 ```
 
 ```shell [dry run]
 # Preview the plan without running the package manager.
-npx ctxo install python --dry-run --pm pnpm
+npx @ctxo/cli install python --dry-run --pm pnpm
 ```
 
 ```shell [pinned version]
 # Pin to an npm dist-tag.
-npx ctxo install typescript --version next --yes
+npx @ctxo/cli install typescript --version next --yes
 ```
 
 ```shell [global]
 # Install globally (useful for ad-hoc CLI usage without a package.json).
-npx ctxo install typescript --global
+npx @ctxo/cli install typescript --global
 ```
 :::
 

--- a/site/docs/cli/overview.md
+++ b/site/docs/cli/overview.md
@@ -9,6 +9,20 @@ description: "All ctxo commands at a glance."
 with no arguments starts the stdio MCP server; any other argument dispatches to
 a subcommand.
 
+## Calling ctxo
+
+`@ctxo/cli` ships as a scoped npm package; the binary name inside the package is `ctxo`. Three equivalent invocation forms:
+
+| Form | When to use |
+| --- | --- |
+| `npx @ctxo/cli <subcommand>` | First-time use, CI, or any project that has not added `@ctxo/cli` to its dependencies yet. Works without any prior install |
+| `npx ctxo <subcommand>` | After `@ctxo/cli` is in the project's `devDependencies` (for example after `ctxo init`). Resolves via `node_modules/.bin/ctxo` |
+| `ctxo <subcommand>` | After a global install (`npm install -g @ctxo/cli`). Works from any directory |
+
+All three forms run the same binary. State always lives in `<project>/.ctxo/` regardless of how `ctxo` is invoked — there is no user-level or system-level config.
+
+Examples below use the `npx @ctxo/cli` form so they work for every reader; substitute the shorter form if you have already installed the package.
+
 ## Command summary
 
 | Command | Purpose |

--- a/site/docs/cli/status.md
+++ b/site/docs/cli/status.md
@@ -13,7 +13,7 @@ Files present in the index but no longer tracked by git are flagged as
 ## Synopsis
 
 ```shell
-npx ctxo status
+npx @ctxo/cli status
 ```
 
 No flags.
@@ -49,12 +49,12 @@ No flags.
 
 ```shell
 # Quickly verify that the project is indexed.
-npx ctxo status
+npx @ctxo/cli status
 ```
 
 ```shell
 # Post-pull check: if cache shows "missing", run sync.
-npx ctxo status && npx ctxo sync
+npx @ctxo/cli status && npx @ctxo/cli sync
 ```
 
 ## Exit codes

--- a/site/docs/cli/sync.md
+++ b/site/docs/cli/sync.md
@@ -14,7 +14,7 @@ it (most commonly after `git pull` or a fresh clone).
 ## Synopsis
 
 ```shell
-npx ctxo sync
+npx @ctxo/cli sync
 ```
 
 No flags.
@@ -34,13 +34,13 @@ No flags.
 ## Examples
 
 ```shell
-npx ctxo sync
+npx @ctxo/cli sync
 ```
 
 ```shell
 # Force a clean cache, then rebuild.
 rm -rf .ctxo/.cache
-npx ctxo sync
+npx @ctxo/cli sync
 ```
 
 ## Exit codes

--- a/site/docs/cli/update.md
+++ b/site/docs/cli/update.md
@@ -18,7 +18,7 @@ row `(latest)` so the channel switch is visible.
 ## Synopsis
 
 ```shell
-npx ctxo update [options]
+npx @ctxo/cli update [options]
 ```
 
 ## Flags
@@ -112,31 +112,31 @@ modes.
 ::: code-group
 ```shell [check]
 # Print the table + suggested command. Always exits 0.
-npx ctxo update --check
+npx @ctxo/cli update --check
 ```
 
 ```shell [apply]
 # Default: run the install when the project has @ctxo/* in package.json,
 # otherwise print the global command for the user to run.
-npx ctxo update
+npx @ctxo/cli update
 ```
 
 ```shell [print only]
 # Useful for CI dashboards or pasting into a chat.
-npx ctxo update --print
+npx @ctxo/cli update --print
 ```
 
 ```shell [global]
 # Force a global install regardless of project layout.
-npx ctxo update --global
+npx @ctxo/cli update --global
 ```
 
 ```shell [JSON]
-npx ctxo update --check --json
+npx @ctxo/cli update --check --json
 ```
 
 ```shell [override pm]
-npx ctxo update --check --pm pnpm
+npx @ctxo/cli update --check --pm pnpm
 ```
 :::
 

--- a/site/docs/cli/visualize.md
+++ b/site/docs/cli/visualize.md
@@ -13,7 +13,7 @@ your default browser by default.
 ## Synopsis
 
 ```shell
-npx ctxo visualize [options]
+npx @ctxo/cli visualize [options]
 ```
 
 ## Flags
@@ -42,21 +42,21 @@ inspection.
 
 ::: code-group
 ```shell [default]
-npx ctxo visualize
+npx @ctxo/cli visualize
 ```
 
 ```shell [large repo]
 # Keep only the 200 most central symbols.
-npx ctxo visualize --max-nodes 200
+npx @ctxo/cli visualize --max-nodes 200
 ```
 
 ```shell [custom path, no browser]
-npx ctxo visualize --output ./reports/graph.html --no-browser
+npx @ctxo/cli visualize --output ./reports/graph.html --no-browser
 ```
 
 ```shell [CI artifact]
 # Generate the HTML in a CI job; upload it as an artifact.
-npx ctxo visualize --output artifacts/ctxo-graph.html --no-browser
+npx @ctxo/cli visualize --output artifacts/ctxo-graph.html --no-browser
 ```
 :::
 

--- a/site/docs/cli/watch.md
+++ b/site/docs/cli/watch.md
@@ -16,7 +16,7 @@ full batch-index cost.
 ## Synopsis
 
 ```shell
-npx ctxo watch
+npx @ctxo/cli watch
 ```
 
 No flags. Press `Ctrl+C` to stop; the watcher drains pending re-index tasks,
@@ -38,12 +38,12 @@ so newly committed changes are reflected immediately.
 
 ```shell
 # Start the watcher in a second terminal while you work.
-npx ctxo watch
+npx @ctxo/cli watch
 ```
 
 ```shell
 # Narrow debug output to just plugin and storage events.
-DEBUG=ctxo:plugin-loader,ctxo:storage npx ctxo watch
+DEBUG=ctxo:plugin-loader,ctxo:storage npx @ctxo/cli watch
 ```
 
 ## When to use this vs. git hooks

--- a/site/docs/integrations/claude-code.md
+++ b/site/docs/integrations/claude-code.md
@@ -77,7 +77,7 @@ to edit anything.
 - **Build the index first.** Claude Code has no way to trigger `ctxo index`
   for you. Run it once after install and let `ctxo watch` keep it fresh.
 - **Hook-based refresh.** Add a `PostToolUse` hook in `.claude/settings.json`
-  that runs `npx ctxo index --skip-history` after `Edit`/`Write` to keep the
+  that runs `npx @ctxo/cli index --skip-history` after `Edit`/`Write` to keep the
   graph fresh between turns.
 - **Team config lives in git.** `.mcp.json` is meant to be committed. Use
   `~/.claude.json` only for personal overrides (e.g., `DEBUG=ctxo:*`).

--- a/site/docs/integrations/raw-mcp-client.md
+++ b/site/docs/integrations/raw-mcp-client.md
@@ -126,7 +126,7 @@ npx tsx ./my-ctxo-script.ts
 
 You should see 14 tool names and a JSON payload for the `SqliteStorageAdapter`
 symbol. If `listTools` returns empty, the index has not been built - run
-`npx ctxo index` in the target repo first.
+`npx @ctxo/cli index` in the target repo first.
 
 ## Tips
 

--- a/site/docs/introduction/installation.md
+++ b/site/docs/introduction/installation.md
@@ -11,6 +11,24 @@ description: "One-liner install: npx @ctxo/cli init, then verify with ctxo docto
 - **git** (any recent version)
 - A supported language: **TypeScript / JavaScript**, **Go**, or **C#**
 
+## Install paths
+
+`@ctxo/cli` is a scoped npm package, so there is no unscoped `ctxo` on the
+registry. Pick whichever invocation form fits your workflow:
+
+1. **No install, ad-hoc** — run `npx @ctxo/cli …` from any directory. npx pulls
+   and runs the package on every call. Best for first-time use, CI, and one-off
+   experiments.
+2. **Project devDependency** — `npm install -D @ctxo/cli` (or just run
+   `npx @ctxo/cli init`, which adds it for you). After that, `npx ctxo …` and
+   `pnpm ctxo …` resolve to the local binary in `node_modules/.bin/ctxo`.
+3. **Global install** — `npm install -g @ctxo/cli` gives you a plain `ctxo`
+   command from any directory. State still lives in each project's `.ctxo/`
+   folder — there is no user-level or system-level config.
+
+The steps below use the no-install form so they work for every reader.
+Substitute `ctxo …` or `npx ctxo …` once you have option 2 or 3 in place.
+
 ## 1. Initialize
 
 From the root of the repo you want to index:
@@ -25,7 +43,7 @@ git hooks, and creates a starter `.ctxo/config.yaml`.
 ## 2. Verify
 
 ```bash
-npx ctxo doctor
+npx @ctxo/cli doctor
 ```
 
 All green? You are done.
@@ -33,7 +51,7 @@ All green? You are done.
 If anything is red or yellow:
 
 ```bash
-npx ctxo doctor --fix
+npx @ctxo/cli doctor --fix
 ```
 
 This runs a dependency-ordered remediation pass (missing plugins, stale
@@ -69,7 +87,7 @@ Available plugins on npm:
 After install, re-index so the plugin takes effect:
 
 ```bash
-npx ctxo index
+npx @ctxo/cli index
 ```
 
 ## Next steps

--- a/site/docs/introduction/mcp-client-setup.md
+++ b/site/docs/introduction/mcp-client-setup.md
@@ -212,8 +212,8 @@ If tools are missing, check the client's MCP logs. Common issues:
 | ----------------------------------- | -------------------------------------------- |
 | `command not found: npx`            | Install Node.js >= 20 and restart the client |
 | Server starts then exits            | Run `npx @ctxo/cli mcp` in a terminal to see the real error |
-| No index loaded                     | Run `npx ctxo index` in the repo root        |
-| Stale results                       | `npx ctxo index` or start `ctxo watch`       |
+| No index loaded                     | Run `npx @ctxo/cli index` in the repo root        |
+| Stale results                       | `npx @ctxo/cli index` or start `ctxo watch`       |
 
 ## Next steps
 

--- a/site/docs/introduction/quick-start.md
+++ b/site/docs/introduction/quick-start.md
@@ -28,13 +28,13 @@ Expected output (abridged):
 [ctxo] Installing @ctxo/lang-typescript@^0.7.0-alpha.0 (devDependency)...
 [ctxo] Wrote .ctxo/config.yaml
 [ctxo] Installed git hooks: post-commit, post-merge, post-checkout
-[ctxo] Done. Run `npx ctxo index` next.
+[ctxo] Done. Run `npx @ctxo/cli index` next.
 ```
 
 ## 2. Build the index
 
 ```bash
-npx ctxo index
+npx @ctxo/cli index
 ```
 
 This walks every file tracked by git, parses symbols and edges, and enriches
@@ -57,7 +57,7 @@ pass. Run a full `ctxo index` before committing.
 ## 3. Check status
 
 ```bash
-npx ctxo status
+npx @ctxo/cli status
 ```
 
 ```
@@ -67,7 +67,7 @@ npx ctxo status
 [ctxo] Health: OK
 ```
 
-If anything looks off, run `npx ctxo doctor` for a detailed health report.
+If anything looks off, run `npx @ctxo/cli doctor` for a detailed health report.
 
 ## 4. Wire up an MCP client
 
@@ -127,6 +127,6 @@ Expected response shape:
 
 ::: tip Keep it fresh
 The git hooks installed by `ctxo init` re-index on commit, merge, and
-checkout. For active editing sessions, run `npx ctxo watch` in a spare
+checkout. For active editing sessions, run `npx @ctxo/cli watch` in a spare
 terminal for incremental re-indexing on save.
 :::

--- a/site/docs/languages/csharp.md
+++ b/site/docs/languages/csharp.md
@@ -41,7 +41,7 @@ yarn add -D @ctxo/lang-csharp
 Or:
 
 ```bash
-npx ctxo install csharp --yes
+npx @ctxo/cli install csharp --yes
 ```
 
 For full tier, install a .NET SDK 8+ alongside Node.js. The helper project

--- a/site/docs/languages/go.md
+++ b/site/docs/languages/go.md
@@ -43,7 +43,7 @@ yarn add -D @ctxo/lang-go
 Or:
 
 ```bash
-npx ctxo install go --yes
+npx @ctxo/cli install go --yes
 ```
 
 For full tier, also install a Go 1.22+ toolchain. The first `ctxo index` run

--- a/site/docs/languages/typescript.md
+++ b/site/docs/languages/typescript.md
@@ -38,10 +38,10 @@ yarn add -D @ctxo/lang-typescript
 Or via the CLI:
 
 ```bash
-npx ctxo install typescript --yes
+npx @ctxo/cli install typescript --yes
 ```
 
-After installing, run `npx ctxo index` to populate `.ctxo/index/`.
+After installing, run `npx @ctxo/cli index` to populate `.ctxo/index/`.
 
 ## What it extracts
 

--- a/site/docs/public/llms.txt
+++ b/site/docs/public/llms.txt
@@ -8,7 +8,7 @@ Ctxo is a Model Context Protocol (MCP) server that delivers Logic-Slices to AI c
 
 - [What is Ctxo?](https://alperhankendi.github.io/Ctxo/docs/introduction/what-is-ctxo): Overview, what it is and is not, how it fits into your stack.
 - [Why Ctxo?](https://alperhankendi.github.io/Ctxo/docs/introduction/why-ctxo): Shift the fix-loop left. Proactive, not reactive.
-- [Installation](https://alperhankendi.github.io/Ctxo/docs/introduction/installation): `npx @ctxo/cli init`, then `npx ctxo doctor`.
+- [Installation](https://alperhankendi.github.io/Ctxo/docs/introduction/installation): `npx @ctxo/cli init`, then `npx @ctxo/cli doctor`.
 - [Quick Start](https://alperhankendi.github.io/Ctxo/docs/introduction/quick-start): Index a repo and make the first MCP call.
 - [MCP Client Setup](https://alperhankendi.github.io/Ctxo/docs/introduction/mcp-client-setup): Claude Code, Cursor, Copilot, Windsurf, Cline, Gemini CLI, Continue.
 

--- a/site/docs/reference/ci-integration.md
+++ b/site/docs/reference/ci-integration.md
@@ -65,7 +65,7 @@ Wire the same check into a local pre-push hook so regressions are caught before 
 # .git/hooks/pre-push
 #!/usr/bin/env bash
 set -e
-npx ctxo index --check || {
+npx @ctxo/cli index --check || {
   echo "ctxo index is stale. Run 'ctxo index' and commit the result." >&2
   exit 1
 }
@@ -95,7 +95,7 @@ For large repos, `--check` still walks the full tree. If the gate is too slow, s
 A stale index produces a diff summary on stderr listing added, removed, and modified files. The expected remediation is:
 
 ```bash
-npx ctxo index
+npx @ctxo/cli index
 git add .ctxo/index
 git commit -m "chore: refresh ctxo index"
 ```

--- a/site/docs/visualizer/index.md
+++ b/site/docs/visualizer/index.md
@@ -42,7 +42,7 @@ visually — the same graph the MCP tools query, but rendered for humans.
 </div>
 
 ::: tip How to get here
-Run <code>npx ctxo visualize</code> in any indexed project. The CLI generates a
+Run <code>npx @ctxo/cli visualize</code> in any indexed project. The CLI generates a
 static HTML file and opens it in your browser.
 :::
 


### PR DESCRIPTION
## Summary

`npx ctxo …` only resolves when `@ctxo/cli` is already in the local `node_modules/.bin/`. First-time users hit `npm error 404 Not Found - GET https://registry.npmjs.org/ctxo` because there is no unscoped `ctxo` package on the registry.

This PR rewrites every user-facing example to the scoped form `npx @ctxo/cli <subcommand>`, which works in every context (no install, post-install, CI). The shorter `npx ctxo` and bare `ctxo` forms still work after install — they are documented as opt-in shortcuts in the new "Calling ctxo" section.

## What changed

**Documentation (28 files):** bulk replace `npx ctxo` → `npx @ctxo/cli` across the VitePress site, `CLAUDE.md`, `llms.txt`, `docs/artifacts/*`, `docs/runbook/real-world-validation/*`, and `examples/community-plugin-template/README.md`.

**New sections explaining the three invocation forms:**
- `site/docs/cli/overview.md` — "Calling ctxo" table (no-install / project dep / global install) with a note that state always lives in `.ctxo/` regardless of install method
- `site/docs/introduction/installation.md` — "Install paths" section recommending global install as a fully-supported option

**Code (2 files):**
- `packages/cli/src/cli/init-command.ts` — the next-steps box shown after `ctxo init` now uses bare `ctxo index` / `ctxo doctor` (no `npx` prefix). After init succeeds, `@ctxo/cli` is guaranteed to be available locally, so this is the shortest working form.
- `packages/cli/src/adapters/transport/http-server-transport.ts` — JSDoc examples updated to `npx @ctxo/cli`.

**Out of scope (intentionally untouched):**
- `CHANGELOG.md`, `docs/superpowers/**`, `docs/architecture/ADR/**`, `docs/archive/**` — historical records.
- `pages/**`, `docs-private/**`, `.changeset/**` — build artifacts / private notes.

## Test plan

- [x] `pnpm --filter @ctxo/cli test` — 1136/1136 pass
- [x] `pnpm -r typecheck` clean
- [x] `pnpm --filter @ctxo/site build` — VitePress site builds, new sections render, no broken links