### PR TITLE
docs: recommend global install + fix broken MCP arg in client configs

### DIFF
--- a/site/docs/integrations/continue.md
+++ b/site/docs/integrations/continue.md
@@ -37,7 +37,7 @@ system reads every `.md` under `.continue/rules/`).
   "mcpServers": {
     "ctxo": {
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"]
+      "args": ["-y", "@ctxo/cli"]
     }
   }
 }

--- a/site/docs/integrations/gemini-cli.md
+++ b/site/docs/integrations/gemini-cli.md
@@ -34,7 +34,7 @@ Drop this into `.gemini/settings.json`:
   "mcpServers": {
     "ctxo": {
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"]
+      "args": ["-y", "@ctxo/cli"]
     }
   }
 }

--- a/site/docs/introduction/installation.md
+++ b/site/docs/introduction/installation.md
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "One-liner install: npx @ctxo/cli init, then verify with ctxo doctor."
+description: "Install @ctxo/cli, then run ctxo init and ctxo doctor."
 ---
 
 # Installation
@@ -11,39 +11,52 @@ description: "One-liner install: npx @ctxo/cli init, then verify with ctxo docto
 - **git** (any recent version)
 - A supported language: **TypeScript / JavaScript**, **Go**, or **C#**
 
-## Install paths
+## Install
 
-`@ctxo/cli` is a scoped npm package, so there is no unscoped `ctxo` on the
-registry. Pick whichever invocation form fits your workflow:
+The npm package is **`@ctxo/cli`** (scoped, so it sits in a namespace alongside
+the language plugins like `@ctxo/lang-typescript`). The binary it installs is
+named **`ctxo`** — that is what you run.
 
-1. **No install, ad-hoc** — run `npx @ctxo/cli …` from any directory. npx pulls
-   and runs the package on every call. Best for first-time use, CI, and one-off
-   experiments.
-2. **Project devDependency** — `npm install -D @ctxo/cli` (or just run
-   `npx @ctxo/cli init`, which adds it for you). After that, `npx ctxo …` and
-   `pnpm ctxo …` resolve to the local binary in `node_modules/.bin/ctxo`.
-3. **Global install** — `npm install -g @ctxo/cli` gives you a plain `ctxo`
-   command from any directory. State still lives in each project's `.ctxo/`
-   folder — there is no user-level or system-level config.
+::: tip Recommended for most users
+Install once globally, then call `ctxo` from any project:
 
-The steps below use the no-install form so they work for every reader.
-Substitute `ctxo …` or `npx ctxo …` once you have option 2 or 3 in place.
+```bash
+npm install -g @ctxo/cli
+```
+
+Verify with `ctxo --version`. To upgrade later: `ctxo update --global`.
+:::
+
+State always lives in each project's `<repo>/.ctxo/` directory — there is no
+user-level or system-level config. The install method only changes how the
+binary is reached, not where data goes.
+
+### Other install paths
+
+| Path | When to use |
+| --- | --- |
+| **Global** — `npm install -g @ctxo/cli` (Recommended) | You work in multiple repos and want `ctxo …` available everywhere. |
+| **Project devDependency** — `npm install -D @ctxo/cli` (or run `npx @ctxo/cli init`, which adds it for you) | You want the version pinned per-project in `package.json`. Call via `pnpm ctxo …`, `npm exec ctxo …`, or use the bare `ctxo` from a project script. |
+| **No install, ad-hoc** — `npx @ctxo/cli <subcommand>` | CI, one-off experiments, or a repo where you do not want to touch dependencies. |
 
 ## 1. Initialize
 
 From the root of the repo you want to index:
 
 ```bash
-npx @ctxo/cli init
+ctxo init
 ```
 
 This detects your languages, installs the right `@ctxo/lang-*` plugins, adds
 git hooks, and creates a starter `.ctxo/config.yaml`.
 
+(If you have not installed globally and not yet added `@ctxo/cli` as a project
+dependency, use `npx @ctxo/cli init` here — it does the same thing.)
+
 ## 2. Verify
 
 ```bash
-npx @ctxo/cli doctor
+ctxo doctor
 ```
 
 All green? You are done.
@@ -51,7 +64,7 @@ All green? You are done.
 If anything is red or yellow:
 
 ```bash
-npx @ctxo/cli doctor --fix
+ctxo doctor --fix
 ```
 
 This runs a dependency-ordered remediation pass (missing plugins, stale
@@ -87,7 +100,7 @@ Available plugins on npm:
 After install, re-index so the plugin takes effect:
 
 ```bash
-npx @ctxo/cli index
+ctxo index
 ```
 
 ## Next steps

--- a/site/docs/introduction/mcp-client-setup.md
+++ b/site/docs/introduction/mcp-client-setup.md
@@ -30,7 +30,7 @@ config):
   "mcpServers": {
     "ctxo": {
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"]
+      "args": ["-y", "@ctxo/cli"]
     }
   }
 }
@@ -43,7 +43,7 @@ Optional debug logging to stderr:
   "mcpServers": {
     "ctxo": {
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"],
+      "args": ["-y", "@ctxo/cli"],
       "env": { "DEBUG": "ctxo:*" }
     }
   }
@@ -62,7 +62,7 @@ Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per-project):
   "mcpServers": {
     "ctxo": {
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"]
+      "args": ["-y", "@ctxo/cli"]
     }
   }
 }
@@ -82,7 +82,7 @@ Copilot Chat (VS Code) reads MCP config from `.vscode/mcp.json`:
     "ctxo": {
       "type": "stdio",
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"]
+      "args": ["-y", "@ctxo/cli"]
     }
   }
 }
@@ -105,7 +105,7 @@ Windsurf reads from `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "ctxo": {
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"]
+      "args": ["-y", "@ctxo/cli"]
     }
   }
 }
@@ -124,7 +124,7 @@ directly:
   "mcpServers": {
     "ctxo": {
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"],
+      "args": ["-y", "@ctxo/cli"],
       "disabled": false,
       "autoApprove": []
     }
@@ -145,7 +145,7 @@ Code and Cursor:
   "mcpServers": {
     "ctxo": {
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"]
+      "args": ["-y", "@ctxo/cli"]
     }
   }
 }
@@ -164,7 +164,7 @@ Continue keeps each MCP server in its own JSON (or YAML) file under
   "mcpServers": {
     "ctxo": {
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"]
+      "args": ["-y", "@ctxo/cli"]
     }
   }
 }

--- a/site/docs/introduction/quick-start.md
+++ b/site/docs/introduction/quick-start.md
@@ -13,12 +13,23 @@ Node.js >= 20, git, and a repo with TypeScript, Go, or C# code. See
 [Installation](/introduction/installation) for details.
 :::
 
+::: tip Get `ctxo` on your PATH
+This guide assumes `ctxo` is already callable. The one-time install:
+
+```bash
+npm install -g @ctxo/cli
+```
+
+Prefer not to install globally? Substitute `npx @ctxo/cli` for `ctxo` in
+every command below.
+:::
+
 ## 1. Install and initialize
 
 From the root of your repo:
 
 ```bash
-npx @ctxo/cli init
+ctxo init
 ```
 
 Expected output (abridged):
@@ -28,13 +39,13 @@ Expected output (abridged):
 [ctxo] Installing @ctxo/lang-typescript@^0.7.0-alpha.0 (devDependency)...
 [ctxo] Wrote .ctxo/config.yaml
 [ctxo] Installed git hooks: post-commit, post-merge, post-checkout
-[ctxo] Done. Run `npx @ctxo/cli index` next.
+[ctxo] Done. Run `ctxo index` next.
 ```
 
 ## 2. Build the index
 
 ```bash
-npx @ctxo/cli index
+ctxo index
 ```
 
 This walks every file tracked by git, parses symbols and edges, and enriches
@@ -57,7 +68,7 @@ pass. Run a full `ctxo index` before committing.
 ## 3. Check status
 
 ```bash
-npx @ctxo/cli status
+ctxo status
 ```
 
 ```
@@ -67,7 +78,7 @@ npx @ctxo/cli status
 [ctxo] Health: OK
 ```
 
-If anything looks off, run `npx @ctxo/cli doctor` for a detailed health report.
+If anything looks off, run `ctxo doctor` for a detailed health report.
 
 ## 4. Wire up an MCP client
 
@@ -79,7 +90,7 @@ Add Ctxo to your client's MCP config. For Claude Code, create or edit
   "mcpServers": {
     "ctxo": {
       "command": "npx",
-      "args": ["@ctxo/cli", "mcp"]
+      "args": ["-y", "@ctxo/cli"]
     }
   }
 }
@@ -127,6 +138,6 @@ Expected response shape:
 
 ::: tip Keep it fresh
 The git hooks installed by `ctxo init` re-index on commit, merge, and
-checkout. For active editing sessions, run `npx @ctxo/cli watch` in a spare
+checkout. For active editing sessions, run `ctxo watch` in a spare
 terminal for incremental re-indexing on save.
 :::


### PR DESCRIPTION
## Summary

Two related fixes:

1. **Promote global install** so users get the bare `ctxo` command — the experience the project name implies. Per-package install stays available and documented.
2. **Fix a real MCP config bug** in five doc examples: they advertised `args: ['@ctxo/cli', 'mcp']` but ctxo has no `mcp` subcommand. The binary starts the MCP server when called with no args. The config that `ctxo init` actually writes is `['-y', '@ctxo/cli']` — docs now match.

## What changed

**Install ergonomics:**
- `site/docs/introduction/installation.md` — global install now the recommended path in a callout at the top of the Install section. The three install paths are kept in a table for context, with global marked Recommended.
- `site/docs/introduction/quick-start.md` — adds a one-time setup tip (`npm install -g @ctxo/cli`) at the top, then uses bare `ctxo` throughout. Users who skip the global install can substitute `npx @ctxo/cli`.

**MCP config bug fix** (5 files, all client integration docs):
- `site/docs/introduction/quick-start.md`
- `site/docs/introduction/mcp-client-setup.md`
- `site/docs/integrations/continue.md`
- `site/docs/integrations/gemini-cli.md`

The change: `args: ["@ctxo/cli", "mcp"]` → `args: ["-y", "@ctxo/cli"]`. This matches the JSON shape that `ctxo init` writes today and what the cli-router actually accepts (no args = MCP stdio server).

## Test plan

- [x] `pnpm --filter @ctxo/site build` — VitePress site builds clean
- [x] Manual: `npm install -g @ctxo/cli@latest && ctxo --version && ctxo update --check` works as documented
- [x] Sweep complete: no remaining `"@ctxo/cli", "mcp"` strings in any non-archived doc

## Why this matters

A new user clones the example MCP config, restarts their client, and sees ctxo fail to start because the binary prints `[ctxo] Unknown command: "mcp"`. The bug never surfaced on automated tests because nothing exercises a freshly-pasted client config end-to-end. The init-command writes the right thing, so users who go through `ctxo init` got working configs anyway — only those who copy-pasted from the website hit the failure.