### PR TITLE
fix(update): skip workspace-linked plugins from install plan

### DIFF
--- a/packages/cli/src/cli/__tests__/update-command.test.ts
+++ b/packages/cli/src/cli/__tests__/update-command.test.ts
@@ -443,4 +443,45 @@ describe('UpdateCommand', () => {
       expect(cap.capture.exitCode).toBeUndefined();
     } finally { cap.restore(); rmSync(dir, { recursive: true, force: true }); }
   });
+
+  it('excludes workspace-linked plugins from the install plan and shows them as workspace link', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ctxo-update-ws-'));
+    // package.json declares @ctxo/cli as a normal devDep but @ctxo/lang-typescript
+    // as a workspace link — exactly what the Ctxo monorepo itself looks like.
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'fixture-monorepo',
+        devDependencies: {
+          '@ctxo/cli': '0.9.1',
+          '@ctxo/lang-typescript': 'workspace:*',
+        },
+      }),
+    );
+    const cap = makeCapture();
+    try {
+      const cmd = new UpdateCommand(dir, {
+        discoverInstalled: async () => [
+          { name: '@ctxo/cli', version: '0.9.1' },
+          { name: '@ctxo/lang-typescript', version: '0.7.0-alpha.0' },
+        ],
+        fetcher: makeFetcher({
+          '@ctxo/cli': { status: 200, body: JSON.stringify({ 'dist-tags': { latest: '0.9.2' } }) },
+          '@ctxo/lang-typescript': { status: 200, body: JSON.stringify({ 'dist-tags': { latest: '0.7.1' } }) },
+        }),
+        runner: cap.deps.runner,
+        setExitCode: cap.deps.setExitCode,
+        env: {},
+      });
+      await cmd.run({ check: true });
+      // The table shows the plugin as workspace link with (local) in the LATEST column.
+      expect(cap.capture.stdout).toContain('@ctxo/lang-typescript');
+      expect(cap.capture.stdout).toContain('workspace link');
+      expect(cap.capture.stdout).toContain('(local)');
+      // The plan only mentions @ctxo/cli; the workspace-linked plugin is excluded.
+      expect(cap.capture.stdout).toMatch(/@ctxo\/cli@0\.9\.2/);
+      expect(cap.capture.stdout).not.toMatch(/@ctxo\/lang-typescript@0\.7\.1/);
+      expect(cap.capture.runs).toHaveLength(0);
+    } finally { cap.restore(); rmSync(dir, { recursive: true, force: true }); }
+  });
 });

--- a/packages/cli/src/cli/update-command.ts
+++ b/packages/cli/src/cli/update-command.ts
@@ -7,6 +7,7 @@ import { fetchDistTagsBatch, type HttpsFetcher } from '../core/update/registry-c
 import {
   computePackageStates,
   detectChannel,
+  markWorkspaceLinks,
   selectInstallTargets,
 } from '../core/update/update-plan.js';
 import {
@@ -14,6 +15,7 @@ import {
   buildInstallCommand,
   isPackageManager,
   isWorkspaceRoot,
+  readWorkspaceLinks,
 } from '../core/install/package-manager.js';
 import { runPackageManager } from '../core/install/run-package-manager.js';
 import { createLogger } from '../core/logger.js';
@@ -56,18 +58,22 @@ export function formatText(report: UpdateReport): string {
     return lines.join('\n');
   }
 
+  const latestCell = (p: PackageState): string => {
+    if (p.status === 'workspace') return '(local)';
+    return p.latest ?? '(not found)';
+  };
+
   const nameCol = Math.max(7, ...report.packages.map((p) => p.name.length));
   const curCol = Math.max(7, ...report.packages.map((p) => p.current.length));
-  const latestCol = Math.max(15, ...report.packages.map((p) => (p.latest ?? '(not found)').length));
+  const latestCol = Math.max(15, ...report.packages.map((p) => latestCell(p).length));
 
   lines.push(
     `${'PACKAGE'.padEnd(nameCol)}  ${'CURRENT'.padEnd(curCol)}  ${`LATEST (${report.channel})`.padEnd(latestCol)}  STATUS`,
   );
   for (const pkg of report.packages) {
-    const latestText = pkg.latest ?? '(not found)';
     const statusText = renderStatus(pkg, report.channel);
     lines.push(
-      `${pkg.name.padEnd(nameCol)}  ${pkg.current.padEnd(curCol)}  ${latestText.padEnd(latestCol)}  ${statusText}`,
+      `${pkg.name.padEnd(nameCol)}  ${pkg.current.padEnd(curCol)}  ${latestCell(pkg).padEnd(latestCol)}  ${statusText}`,
     );
   }
 
@@ -90,6 +96,7 @@ function renderStatus(pkg: PackageState, reportChannel: Channel): string {
   switch (pkg.status) {
     case 'current': return 'up to date';
     case 'ahead': return 'ahead of registry';
+    case 'workspace': return 'workspace link';
     case 'unknown': return pkg.reason === 'registry-404' ? 'skipped' : `error${pkg.reason ? ` (${pkg.reason})` : ''}`;
     case 'update':
       return pkg.channel === reportChannel ? 'update' : `update (${pkg.channel})`;
@@ -162,7 +169,11 @@ export class UpdateCommand {
       return;
     }
 
-    const states = computePackageStates(installed, results);
+    const rawStates = computePackageStates(installed, results);
+    // Drop workspace-linked packages from the install plan; they live in this
+    // repo as `workspace:*` deps, not registry consumers. Keep them visible in
+    // the report so users see why they were skipped.
+    const states = markWorkspaceLinks(rawStates, readWorkspaceLinks(this.projectRoot));
     const targets = selectInstallTargets(states);
 
     const cliVersion = getVersion();

--- a/packages/cli/src/core/install/__tests__/package-manager.test.ts
+++ b/packages/cli/src/core/install/__tests__/package-manager.test.ts
@@ -7,6 +7,7 @@ import {
   buildInstallCommand,
   isPackageManager,
   isWorkspaceRoot,
+  readWorkspaceLinks,
   PACKAGE_MANAGERS,
 } from '../package-manager.js';
 
@@ -275,5 +276,72 @@ describe('isWorkspaceRoot', () => {
   it('returns false on malformed package.json (warn-and-continue)', () => {
     writeFileSync(join(tmp, 'package.json'), '{ not valid json');
     expect(isWorkspaceRoot(tmp)).toBe(false);
+  });
+});
+
+describe('readWorkspaceLinks', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'ctxo-wslinks-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns empty set when no package.json exists', () => {
+    expect(readWorkspaceLinks(tmp).size).toBe(0);
+  });
+
+  it('returns empty set on malformed package.json', () => {
+    writeFileSync(join(tmp, 'package.json'), '{ not valid json');
+    expect(readWorkspaceLinks(tmp).size).toBe(0);
+  });
+
+  it('returns names of deps with workspace: prefix from devDependencies', () => {
+    writeFileSync(
+      join(tmp, 'package.json'),
+      JSON.stringify({
+        name: 'fixture',
+        devDependencies: {
+          '@ctxo/lang-typescript': 'workspace:*',
+          '@ctxo/lang-go': 'workspace:^',
+          tsx: '^4.21.0',
+        },
+      }),
+    );
+    const links = readWorkspaceLinks(tmp);
+    expect(links).toEqual(new Set(['@ctxo/lang-typescript', '@ctxo/lang-go']));
+  });
+
+  it('reads from dependencies, peerDependencies, optionalDependencies too', () => {
+    writeFileSync(
+      join(tmp, 'package.json'),
+      JSON.stringify({
+        name: 'fixture',
+        dependencies: { 'pkg-a': 'workspace:*' },
+        devDependencies: { 'pkg-b': 'workspace:^1.0.0' },
+        peerDependencies: { 'pkg-c': 'workspace:~' },
+        optionalDependencies: { 'pkg-d': 'workspace:*' },
+      }),
+    );
+    expect(readWorkspaceLinks(tmp)).toEqual(new Set(['pkg-a', 'pkg-b', 'pkg-c', 'pkg-d']));
+  });
+
+  it('ignores deps with regular version ranges', () => {
+    writeFileSync(
+      join(tmp, 'package.json'),
+      JSON.stringify({
+        name: 'fixture',
+        devDependencies: {
+          'pkg-a': '^1.0.0',
+          'pkg-b': '~2.0.0',
+          'pkg-c': 'latest',
+          'pkg-d': 'file:../local',
+        },
+      }),
+    );
+    expect(readWorkspaceLinks(tmp).size).toBe(0);
   });
 });

--- a/packages/cli/src/core/install/package-manager.ts
+++ b/packages/cli/src/core/install/package-manager.ts
@@ -152,6 +152,40 @@ export interface InstallInvocation {
 }
 
 /**
+ * Read every dependency in `projectRoot`'s `package.json` whose version spec
+ * starts with `workspace:` (pnpm / yarn workspaces convention, e.g.
+ * `workspace:*`, `workspace:^`, `workspace:~`). Returns a Set of package names.
+ *
+ * Used by `ctxo update` to skip these packages: their source is local, so
+ * "upgrading" them to a registry version would unlink the workspace and
+ * silently downgrade you to whatever npm has published.
+ */
+export function readWorkspaceLinks(projectRoot: string): Set<string> {
+  const links = new Set<string>();
+  const pkgPath = join(projectRoot, 'package.json');
+  if (!existsSync(pkgPath)) return links;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    };
+    for (const group of [pkg.dependencies, pkg.devDependencies, pkg.peerDependencies, pkg.optionalDependencies]) {
+      if (!group) continue;
+      for (const [name, spec] of Object.entries(group)) {
+        if (typeof spec === 'string' && spec.startsWith('workspace:')) {
+          links.add(name);
+        }
+      }
+    }
+    return links;
+  } catch {
+    return links;
+  }
+}
+
+/**
  * True when `projectRoot` is the root of a pnpm workspace. Detects either
  * `pnpm-workspace.yaml` (the explicit pnpm marker) or a `package.json` whose
  * `workspaces` field declares sub-packages. Required so `buildInstallCommand`

--- a/packages/cli/src/core/update/__tests__/update-plan.test.ts
+++ b/packages/cli/src/core/update/__tests__/update-plan.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { detectChannel, compareSemver, computePackageStates, selectInstallTargets, isSafeVersionSpecifier } from '../update-plan.js';
+import {
+  detectChannel,
+  compareSemver,
+  computePackageStates,
+  selectInstallTargets,
+  isSafeVersionSpecifier,
+  markWorkspaceLinks,
+} from '../update-plan.js';
 import type { RegistryResult } from '../registry-client.js';
 
 describe('detectChannel', () => {
@@ -143,5 +150,40 @@ describe('selectInstallTargets safety', () => {
       { name: 'evil', current: '1.0.0', latest: '2.0.0 && rm -rf /', channel: 'latest', status: 'update' },
     ]);
     expect(targets).toEqual([{ name: 'safe', version: '2.0.0' }]);
+  });
+});
+
+describe('markWorkspaceLinks', () => {
+  it('overrides matching names to status workspace and nulls their latest', () => {
+    const out = markWorkspaceLinks(
+      [
+        { name: '@ctxo/cli', current: '0.9.1', latest: '0.9.2', channel: 'latest', status: 'update' },
+        { name: '@ctxo/lang-typescript', current: '0.7.0-alpha.0', latest: '0.7.1', channel: 'latest', status: 'update' },
+        { name: 'other', current: '1.0.0', latest: '1.0.0', channel: 'latest', status: 'current' },
+      ],
+      new Set(['@ctxo/lang-typescript']),
+    );
+    expect(out[0]).toMatchObject({ name: '@ctxo/cli', status: 'update' });
+    expect(out[1]).toMatchObject({ name: '@ctxo/lang-typescript', status: 'workspace', latest: null });
+    expect(out[2]).toMatchObject({ name: 'other', status: 'current' });
+  });
+
+  it('makes selectInstallTargets exclude the marked rows', () => {
+    const states = markWorkspaceLinks(
+      [
+        { name: 'a', current: '1.0.0', latest: '2.0.0', channel: 'latest', status: 'update' },
+        { name: 'b', current: '1.0.0', latest: '2.0.0', channel: 'latest', status: 'update' },
+      ],
+      new Set(['b']),
+    );
+    expect(selectInstallTargets(states)).toEqual([{ name: 'a', version: '2.0.0' }]);
+  });
+
+  it('is a no-op when workspaceLinkNames is empty', () => {
+    const input = [
+      { name: 'a', current: '1.0.0', latest: '2.0.0', channel: 'latest', status: 'update' as const },
+    ];
+    const out = markWorkspaceLinks(input, new Set());
+    expect(out).toEqual(input);
   });
 });

--- a/packages/cli/src/core/update/update-plan.ts
+++ b/packages/cli/src/core/update/update-plan.ts
@@ -70,7 +70,7 @@ export function compareSemver(a: string, b: string): -1 | 0 | 1 {
   return 0;
 }
 
-export type PackageStatus = 'current' | 'update' | 'ahead' | 'unknown';
+export type PackageStatus = 'current' | 'update' | 'ahead' | 'unknown' | 'workspace';
 
 export interface PackageState {
   readonly name: string;
@@ -123,6 +123,24 @@ export function selectInstallTargets(states: readonly PackageState[]): ReadonlyA
     .filter((s): s is PackageState & { latest: string } => s.status === 'update' && typeof s.latest === 'string')
     .filter((s) => isSafeVersionSpecifier(s.latest))
     .map((s) => ({ name: s.name, version: s.latest }));
+}
+
+/**
+ * Override the status of any package whose name appears in `workspaceLinkNames`
+ * to `'workspace'`. Workspace-linked packages (pnpm `workspace:*` / yarn
+ * `workspace:^`) are local source, not registry consumers — they must never
+ * appear in the install plan or be "upgraded" to a registry version. They are
+ * still shown in the report table so users see why a row is being skipped.
+ */
+export function markWorkspaceLinks(
+  states: readonly PackageState[],
+  workspaceLinkNames: ReadonlySet<string>,
+): PackageState[] {
+  return states.map((s) =>
+    workspaceLinkNames.has(s.name)
+      ? { ...s, status: 'workspace' as const, latest: null }
+      : s,
+  );
 }
 
 // Strict semver-ish regex: digits, letters, dots, plus, minus only. Matches the


### PR DESCRIPTION
## Summary

`ctxo update` running inside a workspace (e.g. the Ctxo monorepo itself) was proposing to "upgrade" `workspace:*` plugin links to hard-pinned npm versions — which would silently unlink the workspace and downgrade to whatever npm has published. Now those rows show as `workspace link` in the report and are excluded from the install plan.

Caught while testing 0.9.2 in this repo: the Plan line listed `@ctxo/lang-typescript@0.7.1` (npm stable) even though the project pins it as `workspace:*` (live alpha source).

## What changed

**`core/install/package-manager.ts`** — new `readWorkspaceLinks(projectRoot)` helper. Reads `package.json` and returns the Set of dep names whose version spec starts with `workspace:` (covers `workspace:*`, `workspace:^`, `workspace:~`, `workspace:^1.0.0`, etc.). Scans `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`.

**`core/update/update-plan.ts`** — adds `'workspace'` to the `PackageStatus` union and a new pure `markWorkspaceLinks(states, workspaceLinkNames)` function. Any state whose name is in the set gets its `status` overridden to `'workspace'` and its `latest` to `null`. `selectInstallTargets` already filters to `status === 'update'`, so the workspace rows naturally drop out of the plan.

**`cli/update-command.ts`** — calls `markWorkspaceLinks` between `computePackageStates` and `selectInstallTargets`. Renderer adds a `'workspace'` case (`'workspace link'`) and shows `'(local)'` in the LATEST column for those rows.

## Test plan

- [x] `pnpm --filter @ctxo/cli test` — 1155/1155 pass (9 new tests: 5 `readWorkspaceLinks` cases, 3 `markWorkspaceLinks` cases, 1 end-to-end UpdateCommand test simulating this monorepo's layout)
- [x] `pnpm -r typecheck` clean
- [x] Smoke in this repo: `ctxo update --print` now correctly excludes all three `@ctxo/lang-*` workspace plugins:
  ```
  PACKAGE                CURRENT        LATEST (latest)  STATUS
  @ctxo/cli              0.9.1          0.9.2            update
  @ctxo/lang-csharp      0.7.0-alpha.0  (local)          workspace link
  @ctxo/lang-go          0.8.0-alpha.0  (local)          workspace link
  @ctxo/lang-typescript  0.7.0-alpha.0  (local)          workspace link

  To update, run:
    pnpm add -D -w @ctxo/cli@0.9.2
  ```