### PR TITLE
fix(lang-csharp): support .slnx format and add MSBuild SDK fallback

### DIFF
--- a/packages/lang-csharp/src/roslyn/solution-discovery.ts
+++ b/packages/lang-csharp/src/roslyn/solution-discovery.ts
@@ -59,7 +59,20 @@ export function discoverSolution(rootDir: string): string | null {
     return allSlns[0]!;
   }
 
-  // 3. .csproj fallback
+  // 3. .slnx (XML solution format, .NET 9+) — root first, then recursive
+  const rootSlnxs = findFiles(rootDir, '.slnx', 0);
+  if (rootSlnxs.length === 1) return rootSlnxs[0]!;
+  if (rootSlnxs.length > 1) {
+    log.info(`Multiple .slnx in root, picking first: ${rootSlnxs[0]}`);
+    return rootSlnxs[0]!;
+  }
+  const allSlnxs = findFiles(rootDir, '.slnx', 3);
+  if (allSlnxs.length > 0) {
+    allSlnxs.sort((a, b) => a.split('/').length - b.split('/').length);
+    return allSlnxs[0]!;
+  }
+
+  // 4. .csproj fallback
   const csprojFiles = findFiles(rootDir, '.csproj', 3);
   if (csprojFiles.length > 0) {
     log.info(`No .sln found, using .csproj: ${csprojFiles[0]}`);

--- a/packages/lang-csharp/tools/ctxo-roslyn/Program.cs
+++ b/packages/lang-csharp/tools/ctxo-roslyn/Program.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Xml.Linq;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -10,7 +11,23 @@ using Microsoft.CodeAnalysis.Operations;
 
 // ── Entry Point ──────────────────────────────────────────────────────
 
-MSBuildLocator.RegisterDefaults();
+// RegisterDefaults() uses the VS installer API on Windows and fails on
+// SDK-only machines (no Visual Studio installed). Fall back to locating
+// the SDK via DOTNET_ROOT or the dotnet executable on PATH.
+try
+{
+    MSBuildLocator.RegisterDefaults();
+}
+catch (InvalidOperationException)
+{
+    var sdkPath = DiscoverDotnetSdkPath();
+    if (sdkPath == null)
+    {
+        WriteError("No MSBuild installation found. Install Visual Studio or .NET SDK 8+.");
+        return 1;
+    }
+    MSBuildLocator.RegisterMSBuildPath(sdkPath);
+}
 
 var jsonOptions = new JsonSerializerOptions
 {
@@ -46,7 +63,36 @@ workspace.WorkspaceFailed += (_, e) =>
         WriteStderr($"Workspace: {e.Diagnostic.Message}");
 };
 
-var solution = await workspace.OpenSolutionAsync(solutionPath);
+// .slnx is the XML-based solution format introduced in .NET 9.
+// MSBuildWorkspace.OpenSolutionAsync does not support it yet, so we
+// parse the XML ourselves and load each project individually.
+Solution solution;
+if (solutionPath.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+{
+    var slnxDoc = XDocument.Load(solutionPath);
+    var projectPaths = slnxDoc.Root?.Descendants()
+        .Where(e => e.Name.LocalName == "Project")
+        .Select(e => (string?)e.Attribute("Path"))
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Select(p => Path.GetFullPath(Path.Combine(solutionDir, p!)))
+        .Where(File.Exists)
+        .ToList() ?? [];
+
+    WriteProgress($"Loading {projectPaths.Count} projects from .slnx...");
+    foreach (var projectPath in projectPaths)
+    {
+        try { await workspace.OpenProjectAsync(projectPath); }
+        catch (ArgumentException ex) when (ex.Message.Contains("already part of the workspace"))
+        {
+            // OpenProjectAsync auto-loads referenced projects; skip duplicates.
+        }
+    }
+    solution = workspace.CurrentSolution;
+}
+else
+{
+    solution = await workspace.OpenSolutionAsync(solutionPath);
+}
 var projectCount = solution.Projects.Count();
 var fileCount = solution.Projects.SelectMany(p => p.Documents).Count(d => IsUserCsFile(d.FilePath));
 
@@ -594,6 +640,47 @@ void WriteStderr(string message) =>
 
 void WriteLine(string json) =>
     Console.WriteLine(json);
+
+// ── MSBuild SDK Discovery ────────────────────────────────────────────
+
+static string? DiscoverDotnetSdkPath()
+{
+    // 1. DOTNET_ROOT environment variable (set by the dotnet installer and some CI systems)
+    var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+    if (!string.IsNullOrEmpty(dotnetRoot))
+    {
+        var found = LatestSdkUnder(Path.Combine(dotnetRoot, "sdk"));
+        if (found != null) return found;
+    }
+
+    // 2. Locate dotnet.exe/dotnet on PATH and look sibling sdk/ folder
+    var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+    var dotnetExeName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
+    foreach (var dir in pathEnv.Split(Path.PathSeparator))
+    {
+        var candidate = Path.Combine(dir.Trim(), dotnetExeName);
+        if (!File.Exists(candidate)) continue;
+        // Resolve symlinks to get the real install root
+        var realDir = Path.GetDirectoryName(new FileInfo(candidate).ResolveLinkTarget(true)?.FullName ?? candidate)!;
+        var found = LatestSdkUnder(Path.Combine(realDir, "sdk"));
+        if (found != null) return found;
+    }
+
+    return null;
+}
+
+static string? LatestSdkUnder(string sdkDir)
+{
+    if (!Directory.Exists(sdkDir)) return null;
+    return Directory.GetDirectories(sdkDir)
+        .Where(d => Version.TryParse(Path.GetFileName(d).Split('-')[0], out _))
+        .OrderByDescending(d =>
+        {
+            Version.TryParse(Path.GetFileName(d).Split('-')[0], out var v);
+            return v;
+        })
+        .FirstOrDefault();
+}
 
 // ── Types ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

C# symbol indexing failed completely on machines with only the .NET SDK installed (no Visual Studio). Two separate bugs combined to cause this:

### Bug 1 — `MSBuildLocator.RegisterDefaults()` crashes on SDK-only machines

On Windows, `RegisterDefaults()` uses the Visual Studio installer API to locate MSBuild. When only the .NET SDK is present (no VS), it throws:

System.InvalidOperationException: No instances of MSBuild could be detected.

The entire `ctxo-roslyn` process exits immediately with code 1 before indexing any symbol.

**Affected:** Any developer running Windows with only `dotnet` SDK (common in CI, minimal dev setups, and .NET 9/10 early adopters who skipped VS).

### Bug 2 — `.slnx` not recognised by `discoverSolution()`

`.slnx` is the new XML-based solution format introduced in .NET 9 ([Microsoft announcement](https://devblogs.microsoft.com/dotnet/introducing-solution-file/)). The `discoverSolution()` function only searches for `.sln` files. When none are found it falls back to the first `.csproj` it finds (depth-first order) — which is often the wrong project and causes `OpenSolutionAsync` to throw a parse error:

Microsoft.Build.Exceptions.InvalidProjectFileException: No file format header found.
d:...\TDistro.Migration\TDistro.Migration.csproj



## Fix

### `packages/lang-csharp/src/roslyn/solution-discovery.ts`

Added `.slnx` discovery as tier 3, between the existing `.sln` recursive search and the `.csproj` fallback. Follows the same root-first, shallowest-match pattern as the `.sln` tiers.

### `packages/lang-csharp/tools/ctxo-roslyn/Program.cs`

**MSBuild fallback:** Wrapped `RegisterDefaults()` in a try/catch. On failure, `DiscoverDotnetSdkPath()` locates the SDK by checking `DOTNET_ROOT` first, then walking `PATH` to find `dotnet[.exe]` and resolving symlinks to the real install root. `LatestSdkUnder()` picks the highest-versioned SDK directory. No paths are hardcoded.

**`.slnx` loader:** When the resolved solution path ends with `.slnx`, the file is parsed as XML (`XDocument.Load`), project `Path` attributes are resolved to absolute paths, and each project is loaded via `OpenProjectAsync`. An `ArgumentException` guard skips projects that `OpenProjectAsync` already pulled in as transitive dependencies (which would otherwise throw "already part of the workspace").

## Testing

Verified on:
- Windows 11, .NET SDK 10.0.108 only (no Visual Studio)
- Project using `TDistro.slnx` (5 projects, `.NET 9/10` XML format)

Result after fix:
[ctxo] Plugin csharp@0.7.0-alpha.0 (full tier) — .cs
[ctxo] Index complete: 461 files indexed
[ctxo]   TypeScript/JS: 267 files (full tier)
[ctxo]   C#: 194 files (full tier)


- `get_blast_radius` returns correct results for all C# symbols
- No Roslyn errors in output

Summary: 
Two bugs prevented C# symbol indexing on SDK-only machines (no VS):

1. MSBuildLocator.RegisterDefaults() throws InvalidOperationException on Windows when only the .NET SDK is installed without Visual Studio, because the locator uses the VS installer API for discovery. Fix: catch the error and fall back to locating the SDK via DOTNET_ROOT or dotnet on PATH.

2. .slnx (XML solution format, introduced in .NET 9) was not recognised by discoverSolution() — it fell through to the .csproj fallback and picked up the wrong project. Fix: add .slnx discovery (root-first, then recursive) between the existing .sln and .csproj tiers. MSBuildWorkspace.OpenSolutionAsync does not yet support .slnx, so when that format is detected, ctxo-roslyn parses the XML directly and loads each project via OpenProjectAsync, skipping any project that was already pulled in as a transitive dependency.

Verified on .NET SDK 10.0.108, no Visual Studio, project using TDistro.slnx:
- ctxo index completes without Roslyn errors
- C# symbols fully indexed (194 files, 24+ GetById methods visible)
- get_blast_radius works correctly for all C# symbols