### PR TITLE
fix(deps): pin tree-sitter grammars to exact versions (closes #106)

### DIFF
--- a/.changeset/pin-tree-sitter-grammars.md
+++ b/.changeset/pin-tree-sitter-grammars.md
@@ -1,0 +1,17 @@
+---
+"@ctxo/lang-csharp": patch
+"@ctxo/lang-go": patch
+"@ctxo/lang-java": patch
+---
+
+Pin tree-sitter grammar deps to exact versions to close the lockfile-regen landmine
+
+The caret ranges on `tree-sitter-c-sharp` (`^0.23.1`), `tree-sitter-go` (`^0.23.4`),
+and `tree-sitter-java` (`^0.23.5`) permitted newer grammar releases whose peer
+`tree-sitter ^0.25.0` is not satisfied by the pinned `tree-sitter@^0.22.4` core.
+Any lockfile regeneration (Dependabot rebase, `pnpm install`, `pnpm update`) could
+silently pull in e.g. `tree-sitter-c-sharp@0.23.5`, which pnpm placed under a
+peer-specific virtual path and skipped its native build script, breaking the DTS
+build with `TS2307: Cannot find module 'tree-sitter-c-sharp'`. Pinning to exact
+versions closes the landmine. A coordinated `tree-sitter@^0.25.0` ecosystem upgrade
+is tracked separately (#106 Option 2).

--- a/packages/lang-csharp/package.json
+++ b/packages/lang-csharp/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "tree-sitter": "^0.22.4",
-    "tree-sitter-c-sharp": "^0.23.1"
+    "tree-sitter-c-sharp": "0.23.1"
   },
   "peerDependencies": {
     "@ctxo/plugin-api": "^0.7.2"

--- a/packages/lang-go/package.json
+++ b/packages/lang-go/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "tree-sitter": "^0.22.4",
-    "tree-sitter-go": "^0.23.4"
+    "tree-sitter-go": "0.23.4"
   },
   "peerDependencies": {
     "@ctxo/plugin-api": "^0.7.2"

--- a/packages/lang-java/package.json
+++ b/packages/lang-java/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "tree-sitter": "^0.22.4",
-    "tree-sitter-java": "^0.23.5"
+    "tree-sitter-java": "0.23.5"
   },
   "peerDependencies": {
     "@ctxo/plugin-api": "^0.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,7 @@ importers:
         specifier: ^0.22.4
         version: 0.22.4
       tree-sitter-c-sharp:
-        specifier: ^0.23.1
+        specifier: 0.23.1
         version: 0.23.1(tree-sitter@0.22.4)
     devDependencies:
       '@ctxo/plugin-api':
@@ -134,7 +134,7 @@ importers:
         specifier: ^0.22.4
         version: 0.22.4
       tree-sitter-go:
-        specifier: ^0.23.4
+        specifier: 0.23.4
         version: 0.23.4(tree-sitter@0.22.4)
     devDependencies:
       '@ctxo/plugin-api':
@@ -159,7 +159,7 @@ importers:
         specifier: ^0.22.4
         version: 0.22.4
       tree-sitter-java:
-        specifier: ^0.23.5
+        specifier: 0.23.5
         version: 0.23.5(tree-sitter@0.22.4)
     devDependencies:
       '@ctxo/plugin-api':


### PR DESCRIPTION
## What

Pin the three tree-sitter grammar deps to exact versions, closing the lockfile-regeneration landmine described in #106:

| Package | Before | After |
|---|---|---|
| `tree-sitter-c-sharp` | `^0.23.1` | `0.23.1` |
| `tree-sitter-go` | `^0.23.4` | `0.23.4` |
| `tree-sitter-java` | `^0.23.5` | `0.23.5` |

## Why

The caret ranges permitted newer grammar releases whose peer `tree-sitter ^0.25.0` is **not** satisfied by the pinned `tree-sitter@^0.22.4` core. Any lockfile regeneration (Dependabot rebase, `pnpm install`, `pnpm update`) could silently pull in e.g. `tree-sitter-c-sharp@0.23.5`, which pnpm places under a peer-specific virtual path and **skips its native build script**, breaking the DTS build with `TS2307: Cannot find module 'tree-sitter-c-sharp'`. This took `master` red after #80 and forced revert `017bcd1`.

Issue #106 recommended Option 1 (pin) for c-sharp; this PR applies it to **all three** grammars since go (#77) and java share the identical landmine.

## Validation (local)

- `pnpm install --frozen-lockfile` → clean, **no** `Ignored build scripts`
- `pnpm -r build` → **EXIT 0**, zero `TS2307`, all three lang packages `Done`
- Lockfile diff: only the specifier lines changed; resolved versions are **unchanged** (already the green ones) — no behavior change, landmine closed

## Release

Includes a changeset bumping `@ctxo/lang-csharp`, `@ctxo/lang-go`, `@ctxo/lang-java` (patch). The coordinated `tree-sitter@^0.25.0` ecosystem upgrade (#106 Option 2) is tracked separately.

Closes #106