### PR TITLE
fix(install): map javascript to @ctxo/lang-typescript plugin

### DIFF
--- a/.changeset/fix-javascript-plugin-mapping.md
+++ b/.changeset/fix-javascript-plugin-mapping.md
@@ -1,0 +1,5 @@
+---
+"@ctxo/cli": patch
+---
+
+Fix `ctxo init`/`install` trying to install a non-existent `@ctxo/lang-javascript` package (npm 404). JavaScript files are handled by `@ctxo/lang-typescript`, so `javascript` now resolves to that plugin. Install specifiers are also deduped so a project surfacing both TypeScript and JavaScript no longer requests `@ctxo/lang-typescript` twice.

--- a/.changeset/pin-tree-sitter-grammars.md
+++ b/.changeset/pin-tree-sitter-grammars.md
@@ -1,0 +1,17 @@
+---
+"@ctxo/lang-csharp": patch
+"@ctxo/lang-go": patch
+"@ctxo/lang-java": patch
+---
+
+Pin tree-sitter grammar deps to exact versions to close the lockfile-regen landmine
+
+The caret ranges on `tree-sitter-c-sharp` (`^0.23.1`), `tree-sitter-go` (`^0.23.4`),
+and `tree-sitter-java` (`^0.23.5`) permitted newer grammar releases whose peer
+`tree-sitter ^0.25.0` is not satisfied by the pinned `tree-sitter@^0.22.4` core.
+Any lockfile regeneration (Dependabot rebase, `pnpm install`, `pnpm update`) could
+silently pull in e.g. `tree-sitter-c-sharp@0.23.5`, which pnpm placed under a
+peer-specific virtual path and skipped its native build script, breaking the DTS
+build with `TS2307: Cannot find module 'tree-sitter-c-sharp'`. Pinning to exact
+versions closes the landmine. A coordinated `tree-sitter@^0.25.0` ecosystem upgrade
+is tracked separately (#106 Option 2).

--- a/packages/cli/src/adapters/diagnostics/checks/language-coverage-check.ts
+++ b/packages/cli/src/adapters/diagnostics/checks/language-coverage-check.ts
@@ -47,7 +47,7 @@ export class LanguageCoverageCheck implements IHealthCheck {
       };
     }
 
-    const packages = missing.map(officialPluginFor).join(' ');
+    const packages = [...new Set(missing.map(officialPluginFor))].join(' ');
     const shortList = missing.join(', ');
     return {
       id: this.id,

--- a/packages/cli/src/cli/__tests__/install-java-tier.test.ts
+++ b/packages/cli/src/cli/__tests__/install-java-tier.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveJavaPackages } from '../install-command.js';
+import { resolveJavaPackages, buildPluginSpecifiers } from '../install-command.js';
 
 describe('resolveJavaPackages', () => {
   it('adds analyzer when JRE present and not syntax-only', () => {
@@ -16,5 +16,31 @@ describe('resolveJavaPackages', () => {
   });
   it('throws on conflicting --full-tier and --syntax-only', () => {
     expect(() => resolveJavaPackages({ jreAvailable: true, fullTier: true, syntaxOnly: true })).toThrow(/full-tier.*syntax-only|syntax-only.*full-tier/i);
+  });
+});
+
+describe('buildPluginSpecifiers', () => {
+  it('maps javascript to the typescript plugin', () => {
+    expect(buildPluginSpecifiers(['javascript'], { jreAvailable: false })).toEqual(['@ctxo/lang-typescript']);
+  });
+
+  it('dedupes typescript + javascript into a single @ctxo/lang-typescript', () => {
+    expect(buildPluginSpecifiers(['typescript', 'javascript'], { jreAvailable: false })).toEqual([
+      '@ctxo/lang-typescript',
+    ]);
+  });
+
+  it('expands java into its tier packages', () => {
+    expect(buildPluginSpecifiers(['java'], { jreAvailable: true })).toEqual([
+      '@ctxo/lang-java',
+      '@ctxo/lang-java-analyzer',
+    ]);
+  });
+
+  it('pins every specifier to the requested version', () => {
+    expect(buildPluginSpecifiers(['go', 'javascript'], { jreAvailable: false, version: '1.2.3' })).toEqual([
+      '@ctxo/lang-go@1.2.3',
+      '@ctxo/lang-typescript@1.2.3',
+    ]);
   });
 });

--- a/packages/cli/src/cli/init-command.ts
+++ b/packages/cli/src/cli/init-command.ts
@@ -256,7 +256,7 @@ export class InitCommand {
         ));
         console.error('');
         const confirm = await clack.confirm({
-          message: pc.cyan(`Install ${missing.map(officialPluginFor).join(' ')}?`),
+          message: pc.cyan(`Install ${[...new Set(missing.map(officialPluginFor))].join(' ')}?`),
           initialValue: true,
         });
         if (clack.isCancel(confirm)) { clack.cancel('Setup cancelled.'); process.exit(0); }
@@ -364,7 +364,7 @@ export class InitCommand {
       s.stop(pc.dim('Installing language plugins...'));
       const installer = new InstallCommand(this.projectRoot);
       await installer.run({ languages: pluginsToInstall, yes: true });
-      results.push(`${pc.green('\u2713')} ${pc.bold(pluginsToInstall.map(officialPluginFor).join(', '))}  ${pc.dim('language plugins installed')}`);
+      results.push(`${pc.green('\u2713')} ${pc.bold([...new Set(pluginsToInstall.map(officialPluginFor))].join(', '))}  ${pc.dim('language plugins installed')}`);
       s.start(pc.dim('Finalizing...'));
     }
 

--- a/packages/cli/src/cli/install-command.ts
+++ b/packages/cli/src/cli/install-command.ts
@@ -41,6 +41,39 @@ export function resolveJavaPackages(opts: { jreAvailable: boolean; fullTier?: bo
   return base;
 }
 
+/**
+ * Build the deduped list of npm specifiers to install for the given languages.
+ *
+ * Resolves each language to its official plugin package (java expands to its tier
+ * packages via {@link resolveJavaPackages}; javascript folds into @ctxo/lang-typescript),
+ * pins to `version` when supplied, and removes duplicates so a project that surfaces
+ * both typescript and javascript does not request @ctxo/lang-typescript twice.
+ * Pure + unit-testable.
+ */
+export function buildPluginSpecifiers(
+  languages: readonly KnownLanguage[],
+  opts: { jreAvailable: boolean; fullTier?: boolean; syntaxOnly?: boolean; version?: string },
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const add = (pkg: string): void => {
+    const spec = opts.version ? `${pkg}@${opts.version}` : pkg;
+    if (seen.has(spec)) return;
+    seen.add(spec);
+    out.push(spec);
+  };
+
+  for (const lang of languages) {
+    if (lang === 'java') {
+      for (const pkg of resolveJavaPackages(opts)) add(pkg);
+    } else {
+      add(officialPluginFor(lang));
+    }
+  }
+
+  return out;
+}
+
 export interface InstallPlan {
   readonly languages: readonly KnownLanguage[];
   readonly packages: readonly string[];
@@ -86,27 +119,23 @@ export class InstallCommand {
       return;
     }
 
-    const specifiers: string[] = [];
-    for (const lang of resolvedLangs) {
-      if (lang === 'java') {
-        const jreAvailable = javaRuntimeAvailable();
-        if (!jreAvailable && !options.fullTier && !options.syntaxOnly) {
-          console.error('[ctxo] JRE 17+ not found; installing Java syntax tier. Install a JRE then run "ctxo install java --full-tier" for resolved call/use edges.');
-        }
-        let javaPkgs: string[];
-        try {
-          javaPkgs = resolveJavaPackages({ jreAvailable, fullTier: options.fullTier, syntaxOnly: options.syntaxOnly });
-        } catch (err) {
-          console.error(`[ctxo] ${(err as Error).message}`);
-          process.exitCode = 1;
-          return;
-        }
-        for (const pkg of javaPkgs) {
-          specifiers.push(options.version ? `${pkg}@${options.version}` : pkg);
-        }
-      } else {
-        specifiers.push(options.version ? `${officialPluginFor(lang)}@${options.version}` : officialPluginFor(lang));
-      }
+    const jreAvailable = resolvedLangs.includes('java') ? javaRuntimeAvailable() : false;
+    if (resolvedLangs.includes('java') && !jreAvailable && !options.fullTier && !options.syntaxOnly) {
+      console.error('[ctxo] JRE 17+ not found; installing Java syntax tier. Install a JRE then run "ctxo install java --full-tier" for resolved call/use edges.');
+    }
+
+    let specifiers: string[];
+    try {
+      specifiers = buildPluginSpecifiers(resolvedLangs, {
+        jreAvailable,
+        fullTier: options.fullTier,
+        syntaxOnly: options.syntaxOnly,
+        version: options.version,
+      });
+    } catch (err) {
+      console.error(`[ctxo] ${(err as Error).message}`);
+      process.exitCode = 1;
+      return;
     }
 
     const invocation = buildInstallCommand(resolution.manager, specifiers, {

--- a/packages/cli/src/core/detection/__tests__/detect-languages.test.ts
+++ b/packages/cli/src/core/detection/__tests__/detect-languages.test.ts
@@ -177,4 +177,8 @@ describe('officialPluginFor', () => {
     expect(officialPluginFor('python')).toBe('@ctxo/lang-python');
     expect(officialPluginFor('typescript')).toBe('@ctxo/lang-typescript');
   });
+
+  it('maps javascript to the typescript plugin (no standalone @ctxo/lang-javascript exists)', () => {
+    expect(officialPluginFor('javascript')).toBe('@ctxo/lang-typescript');
+  });
 });

--- a/packages/cli/src/core/detection/detect-languages.ts
+++ b/packages/cli/src/core/detection/detect-languages.ts
@@ -194,5 +194,8 @@ export function decideNeededLanguages(
 
 /** Map a language id to its canonical official npm plugin package name. */
 export function officialPluginFor(language: KnownLanguage): string {
-  return `@ctxo/lang-${language}`;
+  // .js/.jsx files are handled by the TypeScript plugin (ts-morph); there is no
+  // standalone @ctxo/lang-javascript package, so javascript resolves to it.
+  const pkgLang = language === 'javascript' ? 'typescript' : language;
+  return `@ctxo/lang-${pkgLang}`;
 }

--- a/packages/lang-csharp/package.json
+++ b/packages/lang-csharp/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "tree-sitter": "^0.22.4",
-    "tree-sitter-c-sharp": "^0.23.1"
+    "tree-sitter-c-sharp": "0.23.1"
   },
   "peerDependencies": {
     "@ctxo/plugin-api": "^0.7.2"

--- a/packages/lang-go/package.json
+++ b/packages/lang-go/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "tree-sitter": "^0.22.4",
-    "tree-sitter-go": "^0.23.4"
+    "tree-sitter-go": "0.23.4"
   },
   "peerDependencies": {
     "@ctxo/plugin-api": "^0.7.2"

--- a/packages/lang-java/package.json
+++ b/packages/lang-java/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "tree-sitter": "^0.22.4",
-    "tree-sitter-java": "^0.23.5"
+    "tree-sitter-java": "0.23.5"
   },
   "peerDependencies": {
     "@ctxo/plugin-api": "^0.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,7 @@ importers:
         specifier: ^0.22.4
         version: 0.22.4
       tree-sitter-c-sharp:
-        specifier: ^0.23.1
+        specifier: 0.23.1
         version: 0.23.1(tree-sitter@0.22.4)
     devDependencies:
       '@ctxo/plugin-api':
@@ -134,7 +134,7 @@ importers:
         specifier: ^0.22.4
         version: 0.22.4
       tree-sitter-go:
-        specifier: ^0.23.4
+        specifier: 0.23.4
         version: 0.23.4(tree-sitter@0.22.4)
     devDependencies:
       '@ctxo/plugin-api':
@@ -159,7 +159,7 @@ importers:
         specifier: ^0.22.4
         version: 0.22.4
       tree-sitter-java:
-        specifier: ^0.23.5
+        specifier: 0.23.5
         version: 0.23.5(tree-sitter@0.22.4)
     devDependencies:
       '@ctxo/plugin-api':


### PR DESCRIPTION
## Problem

`ctxo init` / `ctxo install` failed when a project surfaced JavaScript:

```
[ctxo] Command: npm install -D @ctxo/lang-java @ctxo/lang-java-analyzer @ctxo/lang-javascript
npm error 404 Not Found - GET https://registry.npmjs.org/@ctxo%2flang-javascript - Not found
```

There is no standalone `@ctxo/lang-javascript` package — `.js`/`.jsx` files are handled by `@ctxo/lang-typescript` (ts-morph). But `officialPluginFor('javascript')` mechanically derived `@ctxo/lang-javascript`, so init/install/index/doctor all tried to install a non-existent package (and treated the JS plugin as perpetually "missing").

## Fix

- `officialPluginFor` folds `javascript` into `@ctxo/lang-typescript`. This corrects both install specifiers and the "is plugin installed?" resolve checks across init/install/index/doctor.
- New pure `buildPluginSpecifiers()` maps languages to packages, expands Java tiers, pins versions, and **dedupes** so a project surfacing both `typescript` and `javascript` no longer requests `@ctxo/lang-typescript` twice. `InstallCommand.run()` now uses it.
- Deduped the user-facing package lists in `init` prompts/results and `language-coverage-check`.

## Tests (TDD: RED → GREEN)

- `officialPluginFor` → javascript resolves to the typescript plugin
- `buildPluginSpecifiers` → mapping, dedup, Java tier expansion, version pinning

Verification: `pnpm --filter @ctxo/cli typecheck` clean; full unit suite 1218/1218 pass.

Fixes #107