### PR TITLE
test: raise vitest timeouts to absorb cold-start module init

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    // The first test in each worker pays one-time module init (language plugins
+    // + sql.js WASM): ~6s on a cold CI runner vs ~0.8s warm. The 5s default
+    // flaked on Node 22 in PR #122.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     include: ['src/**/__tests__/**/*.test.ts', 'tests/**/*.test.ts'],
     reporters: ['default', 'junit'],
     outputFile: {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,10 +4,10 @@ export default defineConfig({
   test: {
     globals: true,
     // The first test in each worker pays one-time module init (language plugins
-    // + sql.js WASM): ~6s on a cold CI runner vs ~0.8s warm. The 5s default
-    // flaked on Node 22 in PR #122.
-    testTimeout: 20_000,
-    hookTimeout: 20_000,
+    // + sql.js WASM): 6-11s on a cold CI runner vs ~0.8s warm. The 5s default
+    // flaked on Node 22 (PR #122) and Node 20. Matches the e2e config budget.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     include: ['src/**/__tests__/**/*.test.ts', 'tests/**/*.test.ts'],
     reporters: ['default', 'junit'],
     outputFile: {

--- a/packages/cli/vitest.config.unit.ts
+++ b/packages/cli/vitest.config.unit.ts
@@ -3,6 +3,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    // The first test in each worker pays one-time module init (language plugins
+    // + sql.js WASM): 6-11s on a cold CI runner vs ~0.8s warm. The 5s default
+    // flaked on Node 22 (PR #122) and Node 20. Matches the e2e config budget.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     include: ['src/**/__tests__/**/*.test.ts'],
     reporters: ['default', 'junit'],
     outputFile: {


### PR DESCRIPTION
Fixes the flaky `Unit Tests` failure seen on #122.

## The failure

```
× IndexCommand > discovers all .ts files in project directory  6054ms
  → Test timed out in 5000ms.
```

Node 20 passed that run; on a later run the same test failed on Node 20 at 10693ms while Node 22 passed. The change in #122 was a lockfile-only SDK bump, so this was never a regression, just a flake that lands on whichever job is slowest that run.

## Root cause

The first test in each vitest worker pays one-time module init: language plugin loads (csharp/go/java/typescript, incl. tree-sitter bindings) plus sql.js WASM. The CI log shows the cost is one-time, not per-test:

| Test | CI time |
|---|---|
| discovers all .ts files (1st) | **6054ms** |
| writes one JSON file per source file | 691ms |
| creates schema-version file | 247ms |
| populates SQLite cache | 271ms |

Observed cold-start cost ranged 6-11s across runs against the 5000ms default.

## Why suite-wide rather than per-test

Four test files construct `IndexCommand` (`index-command`, `index-command-ignore`, `index-command.intent`, `verify-command`), and vitest gives each file its own worker process, so each pays the init independently. Their first tests run 500ms / 785ms / 856ms / 1030ms warm locally. At the cold-start scaling seen on CI, all four sit near the ceiling, so pinning a timeout on the one test that happened to fail would just relocate the flake.

## The change

`testTimeout` and `hookTimeout` set to 30s in:

- `vitest.config.unit.ts` - what `test:unit` / `test:unit:coverage` actually run, so this is the one that fixes CI
- `vitest.config.ts` - what `pnpm -r test` runs, incl. the release workflow gate

30s matches the budget `vitest.config.e2e.ts` already uses. `hookTimeout` is included because `beforeEach` does a real `git init` + commit + recursive copy per test.

## Verification

- CI green on this branch: Unit Tests Node 20 + Node 22, E2E, Build, Lint & Typecheck, CodeQL, Dependency Audit
- Local unit suite: 1218/1218 pass
- Confirmed the new limit is live by running a temporary 7s probe test under `--config vitest.config.unit.ts` (would fail under the old 5s default); probe removed before commit

No changeset: test-config only, no published behavior change.