### PR TITLE
ci(release): pin changesets/action back to v1.9.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     groups:
       actions:
         patterns: ['*']
+    ignore:
+      # changesets/action v2+ requires Changesets CLI v3 and renames every
+      # input/output this workflow uses. #126 auto-merged the v1 -> v2 jump and
+      # broke the release pipeline. Hold at v1 until the CLI v3 migration is
+      # done deliberately, then drop this ignore.
+      - dependency-name: changesets/action
+        versions: ['>=2']
 
   - package-ecosystem: npm
     directory: /

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           # `pnpm release` runs `pnpm -r build && changeset publish` per root
           # package.json. changesets/action calls this only when no pending


### PR DESCRIPTION
The Release workflow has been failing on **every master push** since #126. Publishing is currently down.

## What broke

#126 (`chore(deps): bump the actions group across 1 directory with 3 updates`) auto-applied a major jump as part of the `actions` group:

```diff
- uses: changesets/action@a45c4d59... # v1.9.0
+ uses: changesets/action@198f833d... # v2.1.0
```

changesets/action v2 requires Changesets CLI v3, but this repo is on `@changesets/cli@^2.31.0`:

```
Error: This version of the Changesets action is designed to work with Changesets CLI v3.
Changesets CLI v2 is not supported; use Changesets action v1 instead, which is compatible with CLI v2.
```

Seen on [the run for #116](https://github.com/alperhankendi/Ctxo/actions/runs/32716745158). Build, typecheck and test all passed - only the `Create Release Pull Request or Publish` step failed.

## The second, quieter problem

v2 also renamed every input and output this workflow uses, so the same run warned:

```
Unexpected input(s) publish, title, commit, createGithubReleases
```

Those were silently dropped in favour of defaults. Notably `createGithubReleases: false` was ignored, and v2 defaults `create-github-releases` to **true** - so a successful v2 run would have re-enabled per-package GitHub Releases, which we deliberately disable in favour of the single umbrella release.

The outputs moved too: `publishedPackages` -> `published-packages`, `hasChangesets` -> `has-changesets`. This workflow reads those in 4 places (dist-tag repair, umbrella release, run summary), all of which would have silently evaluated empty.

## The fix

Revert the pin to v1.9.0. Its `action.yml` has exactly what this workflow uses:

| Used by workflow | v1.9.0 | v2.1.0 |
|---|---|---|
| `publish` | yes | renamed `publish-script` |
| `title` | yes | renamed `pr-title` |
| `commit` | yes | renamed `commit-message` |
| `createGithubReleases` | yes | renamed `create-github-releases` |
| `outputs.published` | yes | yes |
| `outputs.publishedPackages` | yes | renamed `published-packages` |
| `outputs.hasChangesets` | yes | renamed `has-changesets` |

The v1.9.0 SHA was verified by dereferencing the annotated tag through the API, not by trusting the comment: `a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d`.

Also adds a dependabot `ignore` for `changesets/action >=2`, so the `actions` group cannot silently re-break the pipeline on the next weekly run.

## Follow-up (deliberate, not now)

Moving to v2 properly needs `@changesets/cli` v3 (available in #120, though that PR also carries TypeScript 7 which breaks the dts build) plus the 4 input and 4 output renames. Worth doing as its own change, where the `ignore` rule gets dropped in the same PR.

## Verification

- v1.9.0 input/output schema fetched from the pinned SHA and checked against every reference in `release.yml`
- Both `release.yml` and `dependabot.yml` parse as valid YAML
- The release workflow only runs on master push, so it cannot be exercised from a PR - this is verified by schema comparison against the last known-good configuration (v1.9.0 was in place and working through #103..#125)